### PR TITLE
Fix curl command line

### DIFF
--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -96,7 +96,7 @@ function install_packages()
 function download()
 {
 	if   [[ $(type -t wget) ]]; then wget -c -O "$2" "$1"
-	elif [[ $(type -t curl) ]]; then curl -C -o "$2" "$1"
+	elif [[ $(type -t curl) ]]; then curl -C - -o "$2" "$1"
 	else
 		error "Could not find wget or curl"
 		return 1


### PR DESCRIPTION
From the curl man page:

> Use  "-C  -"  to  tell  curl to automatically find out where/how to resume the
>              transfer. It then uses the given output/input files to figure that out.

Refs #17
