### PR TITLE
Fix typo in ruby/functions.sh

### DIFF
--- a/share/ruby-install/ruby/functions.sh
+++ b/share/ruby-install/ruby/functions.sh
@@ -14,7 +14,7 @@ function configure_ruby()
 		./configure --prefix="$INSTALL_DIR" \
 			    --with-openssl-dir=`brew --prefix openssl` \
 			    --with-readline-dir=`brew --prefix readline` \
-			    --with-yaml-dir=`brew --prefix yaml` \
+			    --with-yaml-dir=`brew --prefix libyaml` \
 			    --with-gdbm-dir=`brew --prefix gdbm` \
 			    --with-libffi-dir=`brew --prefix libffi` \
 			    $CONFIGURE_OPTS


### PR DESCRIPTION
The canonical name in Homebrew is libyaml (though we should probably add an alias).
