### PR TITLE
Update Homebrew dependencies for Rubinius

### DIFF
--- a/share/ruby-install/rubinius/dependencies.txt
+++ b/share/ruby-install/rubinius/dependencies.txt
@@ -1,4 +1,4 @@
 apt: gcc g++ automake flex bison ruby-dev rake zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev
 yum: gcc gcc-c++ automake flex bison ruby-devel rubygems rubygem-rake llvm-devel zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel
-brew: libyaml gdbm
+brew: openssl readline libyaml gdbm libffi
 pacman: gcc automake flex bison ruby zlib libyaml openssl gdbm readline ncurses


### PR DESCRIPTION
The configure_ruby() function for Rubinius already assumes these dependencies are present:

https://github.com/postmodern/ruby-install/blob/1a78634bac21a7c90a0f01b7b618926662134238/share/ruby-install/rubinius/functions.sh#L26

so update this list to match.
