### PR TITLE
Don't pass libffi prefix for Rubinius

### DIFF
--- a/share/ruby-install/rubinius/functions.sh
+++ b/share/ruby-install/rubinius/functions.sh
@@ -23,7 +23,7 @@ function configure_ruby()
 
 	if [[ "$PACKAGE_MANAGER" == "brew" ]]; then
 		./configure --prefix="$INSTALL_DIR" \
-			    --with-opt-dir="$(brew --prefix openssl):$(brew --prefix readline):$(brew --prefix libyaml):$(brew --prefix gdbm):$(brew --prefix libffi)" \
+			    --with-opt-dir="$(brew --prefix openssl):$(brew --prefix readline):$(brew --prefix libyaml):$(brew --prefix gdbm)" \
 			    $CONFIGURE_OPTS
 	else
 		./configure --prefix="$INSTALL_DIR" $CONFIGURE_OPTS


### PR DESCRIPTION
Since they vendor libffi, this is unnecessary. Refs #23.
