### PR TITLE
If intermediate .rubies/ dir doesn't exist, create it during JRuby and MagLev installs.

### DIFF
--- a/share/ruby-install/functions.sh
+++ b/share/ruby-install/functions.sh
@@ -4,6 +4,7 @@
 function pre_install()
 {
 	mkdir -p "$SRC_DIR"
+	mkdir -p $(dirname "$INSTALL_DIR")
 
 	log "Updating Package Manager"
 	update_package_manager


### PR DESCRIPTION
The .rubies/ directory is created with a ruby-install of Ruby but not so with JRuby and MagLev mv to $INSTALL_DIR. Trying to install JRuby or MagLev before installing Ruby fails due to missing .rubies/ dir.
