### PR TITLE
Do not run `yum updateinfo`.

### DIFF
--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -93,7 +93,7 @@ function update_package_manager()
 {
 	case "$PACKAGE_MANAGER" in
 		apt)	sudo apt-get update ;;
-		yum)	sudo yum updateinfo ;;
+		yum)	:                   ;;
 		brew)	brew update         ;;
 	esac
 }


### PR DESCRIPTION
Yum doesn't need anything to be done in the pre install step (case left there
with a noop for clarity). Solves #33. 
