### PR TITLE
Allow curl to follow redirects.

### DIFF
--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -121,7 +121,7 @@ function install_packages()
 function download()
 {
 	case "$DOWNLOADER" in
-		wget) wget -c -O "$2" "$1"   ;;
+		wget) wget -c -O "$2" "$1"      ;;
 		curl) curl -L -C - -o "$2" "$1" ;;
 		"")
 			error "Could not find wget or curl"


### PR DESCRIPTION
This is needed, for instance, to actually download a copy of Rubinius and not
GitHub's redirect page output which completely breaks RBX installations.
