### PR TITLE
Support `sudo ruby-install` with brew on OS X.

### DIFF
--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -102,7 +102,10 @@ function install_packages()
 	case "$PACKAGE_MANAGER" in
 		apt)	$SUDO apt-get install -y $* ;;
 		yum)	$SUDO yum install -y $*     ;;
-		brew)	brew install $*            ;;
+		brew)
+			local brew_owner=$(stat -f %Su /usr/local/bin/brew)
+			sudo -u $brew_owner brew install $*
+			;;
 		pacman)
 			local missing_pkgs=$(pacman -T $*)
 


### PR DESCRIPTION
When ruby-install is run with `sudo` or as root it fails with the message: Error: Cowardly refusing to `sudo brew install`. Fix by running `brew` as the brew-file (/usr/local) owner rather than as root.
