### PR TITLE
Add support for URLs as -p option values.

### DIFF
--- a/bin/ruby-install
+++ b/bin/ruby-install
@@ -33,6 +33,7 @@ if [[ ! $NO_VERIFY -eq 1 ]]; then
 fi
 
 extract_ruby   || fail "Unpacking of $RUBY_ARCHIVE failed!"
+download_patches || fail "Fetching patches $PATCHES failed!"
 apply_patches  || fail "Patching $RUBY $RUBY_VERSION failed!"
 cd "$SRC_DIR/$RUBY_SRC_DIR"
 configure_ruby || fail "Configuration of $RUBY $RUBY_VERSION failed!"

--- a/share/ruby-install/functions.sh
+++ b/share/ruby-install/functions.sh
@@ -67,12 +67,30 @@ function extract_ruby()
 }
 
 #
+# Download any additional patches
+#
+function download_patches()
+{
+	for path in ${PATCHES[*]}; do
+		if [[ $path == http:\/\/* || $path == https:\/\/* ]]; then
+			log "Downloading patch $path ..."
+			patch=$(basename $path)
+			download "$path" "$SRC_DIR/$patch"
+		fi
+	done
+}
+
+#
 # Apply any additional patches
 #
 function apply_patches()
 {
 	for path in ${PATCHES[*]}; do
 		log "Applying patch $(basename $path) ..."
+		if [[ $path == http:\/\/* || $path == https:\/\/* ]]; then
+			patch=$(basename $path)
+			path="$SRC_DIR/$patch"
+		fi
 		patch -p1 -d "$SRC_DIR/$RUBY_SRC_DIR" < "$path"
 	done
 }

--- a/test/remote_patches_test.sh
+++ b/test/remote_patches_test.sh
@@ -1,0 +1,42 @@
+. ./test/helper.sh
+
+PATCHES="https://raw.github.com/gist/4136373/falcon-gc.diff local.patch"
+
+test_download_patches()
+{
+	local dir="test/subdir"
+	local SRC_DIR=$dir
+
+	mkdir -p "$dir"
+
+	download_patches 2>/dev/null
+
+	assertTrue "did not download patches to the directory" \
+		'[[ -f "$dir/falcon-gc.diff" ]]'
+
+	rm -r "$dir"
+}
+
+test_apply_patches()
+{
+	local dir="test/subdir"
+	local SRC_DIR=$dir
+
+	mkdir -p "$dir"
+	echo "
+diff -Naur subdir.orig/test subdir/test
+--- subdir.orig/test 1970-01-01 01:00:00.000000000 +0100
++++ subdir/test  2013-08-02 20:57:08.055843749 +0200
+@@ -0,0 +1 @@
++patch
+" 	> "$dir/falcon-gc.diff"
+
+	apply_patches 2>/dev/null
+
+	assertTrue "did not apply downloaded patches" \
+		'[[ -f "$dir/test" ]]'
+
+	rm -r "$dir"
+}
+
+SHUNIT_PARENT=$0 . $SHUNIT2


### PR DESCRIPTION
Try to download any patches specified via the -p option that start with
http or https and apply them.

So this example from README would really work:

$ ruby-install -p https://raw.github.com/gist/4136373/falcon-gc.diff ruby 1.9.3-p429
