### PR TITLE
Added `disable-install-doc` option to help section

### DIFF
--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -236,6 +236,7 @@ Options:
 	--no-verify		Do not verify the downloaded Ruby archive
 	--no-install-deps	Do not install build dependencies before installing Ruby
 	--no-reinstall  	Skip installation if another Ruby is detected in same location
+	--disable-install-doc  	Do not generate documentation
 	-V, --version		Prints the version
 	-h, --help		Prints this message
 


### PR DESCRIPTION
Not sure if this really belongs to `ruby-install`, but it's handy to have it documented.
