### PR TITLE
Check for existance of $INSTALL_DIR pre-install

### DIFF
--- a/share/ruby-install/functions.sh
+++ b/share/ruby-install/functions.sh
@@ -1,10 +1,12 @@
 if (( $UID == 0 )); then
 	SRC_DIR="${SRC_DIR:-/usr/local/src}"
-	INSTALL_DIR="${INSTALL_DIR:-/opt/rubies/$RUBY-$RUBY_VERSION}"
+	INSTALL_DIR="${INSTALL_DIR:-/opt/rubies}"
 else
 	SRC_DIR="${SRC_DIR:-$HOME/src}"
-	INSTALL_DIR="${INSTALL_DIR:-$HOME/.rubies/$RUBY-$RUBY_VERSION}"
+	INSTALL_DIR="${INSTALL_DIR:-$HOME/.rubies}"
 fi
+
+[[ -d "$INSTALL_DIR" ]] && INSTALL_DIR="$INSTALL_DIR/$RUBY-$RUBY_VERSION"
 
 #
 # Pre-install tasks


### PR DESCRIPTION
As a fix for #56 and #57, check to see if `$INSTALL_DIR` is already a
directory. If it is, install the specified Ruby to
`$INSTALL_DIR/$RUBY-$RUBY_VERSION`. If it isn't, install directly to
`$INSTALL_DIR`. The default for this directory is still the same:
`/opt/rubies` or `~/.rubies`, but this prevents problems such as specifying
`ruby-install -i ~/.rbenv/versions ruby 2.0.0` causing Ruby 2.0.0 to be
installed with `~/.rbenv/versions` as the root directory rather than
`~/.rbenv/versions/ruby-2.0.0-p247`

It is my opinion that an additional `--rubies-dir` option is unnecessary,
but perhaps others disagree with this. IMO this quick check is simpler
and effective.

Signed-off-by: David Celis me@davidcel.is
