### PR TITLE
Add --rubies-dir (-r) option

### DIFF
--- a/share/ruby-install/functions.sh
+++ b/share/ruby-install/functions.sh
@@ -1,10 +1,12 @@
 if (( $UID == 0 )); then
 	SRC_DIR="${SRC_DIR:-/usr/local/src}"
-	INSTALL_DIR="${INSTALL_DIR:-/opt/rubies/$RUBY-$RUBY_VERSION}"
+	RUBIES_DIR="${RUBIES_DIR:-/opt/rubies}"
 else
 	SRC_DIR="${SRC_DIR:-$HOME/src}"
-	INSTALL_DIR="${INSTALL_DIR:-$HOME/.rubies/$RUBY-$RUBY_VERSION}"
+	RUBIES_DIR="${RUBIES_DIR:-$HOME/.rubies}"
 fi
+
+INSTALL_DIR="${INSTALL_DIR:-$RUBIES_DIR/$RUBY-$RUBY_VERSION}"
 
 #
 # Pre-install tasks

--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -228,6 +228,7 @@ Options:
 
 	-s, --src-dir DIR	Directory to download source-code into
 	-i, --install-dir DIR	Directory to install Ruby into
+	-r, --rubies-dir DIR  Directory that contains other installed Rubies
 	-p, --patch FILE	Patch to apply to the Ruby source-code
 	-M, --mirror URL	Alternate mirror to download the Ruby archive from
 	-u, --url URL		Alternate URL to download the Ruby archive from
@@ -263,6 +264,10 @@ function parse_options()
 		case $1 in
 			-i|--install-dir)
 				INSTALL_DIR="$2"
+				shift 2
+				;;
+			-r|--rubies-dir)
+				RUBIES_DIR="$2"
 				shift 2
 				;;
 			-s|--src-dir)

--- a/test/load_ruby_test.sh
+++ b/test/load_ruby_test.sh
@@ -74,24 +74,38 @@ function test_SRC_DIR()
 	fi
 }
 
+function test_RUBIES_DIR()
+{
+	load_ruby
+
+	if (( $UID == 0 )); then
+		assertEquals "did not correctly default RUBIES_DIR" \
+			     "/opt/rubies" \
+			     "$RUBIES_DIR"
+	else
+		assertEquals "did not correctly default RUBIES_DIR" \
+			     "$HOME/.rubies" \
+			     "$RUBIES_DIR"
+}
+
 function test_INSTALL_DIR()
 {
 	load_ruby
 
 	if (( $UID == 0 )); then
 		assertEquals "did not correctly default INSTALL_DIR" \
-			     "/opt/rubies/$RUBY-$EXPANDED_RUBY_VERSION" \
+			     "$RUBIES_DIR/$RUBY-$EXPANDED_RUBY_VERSION" \
 			     "$INSTALL_DIR"
 	else
 		assertEquals "did not correctly default INSTALL_DIR" \
-			     "$HOME/.rubies/$RUBY-$EXPANDED_RUBY_VERSION" \
+			     "$RUBIES_DIR/$RUBY-$EXPANDED_RUBY_VERSION" \
 			     "$INSTALL_DIR"
 	fi
 }
 
 function tearDown()
 {
-	unset SRC_DIR INSTALL_DIR
+	unset SRC_DIR RUBIES_DIR INSTALL_DIR
 	unset RUBY RUBY_VERSION RUBY_MD5 RUBY_ARCHIVE RUBY_SRC_DIR RUBY_URL
 }
 


### PR DESCRIPTION
This option allows the default installation directory for Ruby to be set
while still creating a `$RUBY-$RUBY_VERSION` subdirectory in the
process. Note that setting --install-dir (-i) will override this option.

Fixes #56 and #57.

Signed-off-by: David Celis me@davidcel.is
