### PR TITLE
Check installed version

### DIFF
--- a/bin/ruby-install
+++ b/bin/ruby-install
@@ -13,7 +13,8 @@ parse_options "$@" || exit $?
 load_ruby          || exit $?
 
 if [[ $NO_REINSTALL -eq 1 ]] && [[ -x "$INSTALL_DIR/bin/ruby" ]]; then
-	fail "Ruby is already installed into $INSTALL_DIR"
+	log "Ruby is already installed into $INSTALL_DIR"
+	exit
 fi
 
 log "Installing $RUBY $RUBY_VERSION into $INSTALL_DIR ..."

--- a/test/no_reinstall_test.sh
+++ b/test/no_reinstall_test.sh
@@ -1,0 +1,27 @@
+. ./test/helper.sh
+
+INSTALL_DIR="./test/dir"
+STDERR="./test/stderr"
+STDOUT="./test/stdout"
+
+function test_no_reinstall_when_ruby_executable_exists()
+{
+	mkdir -p "$INSTALL_DIR/bin"
+	touch -m "$INSTALL_DIR/bin/ruby"
+	chmod +x "$INSTALL_DIR/bin/ruby"
+
+	ruby-install --install-dir "$INSTALL_DIR" --no-reinstall ruby \
+		> "$STDOUT" 2> "$STDERR"
+
+	assertEquals "did not return 0" 0 $?
+	assertTrue "did not print a message to STDOUT" \
+		'[[ $(cat $STDOUT) == *"already installed"* ]]'
+}
+
+function tearDown()
+{
+	rm -r "$INSTALL_DIR"
+	rm -f "$STDERR" "$STDOUT"
+}
+
+SHUNIT_PARENT=$0 . $SHUNIT2


### PR DESCRIPTION
I would like to check if the stable version of a ruby is installed. Something like `ruby-install --query ruby`.

Using the `--no-reinstall` option returns a non-zero status when it is already installed, but it is difficult to systematically distinguish between "already installed" and "build failure".
