### PR TITLE
Add --jobs flag to make for parallel compiling

### DIFF
--- a/share/ruby-install/ruby/functions.sh
+++ b/share/ruby-install/ruby/functions.sh
@@ -17,6 +17,20 @@ if [[ "$RUBY_VERSION_FAMILY" == "1.8" ]]; then
 fi
 
 #
+# Get number of cores.
+#
+cores() {
+  local num=""
+  if [[ "Darwin" = "$(uname -s)" ]]; then
+    num="$(sysctl -n hw.ncpu 2>/dev/null || true)"
+  elif [[ -r /proc/cpuinfo ]]; then
+    num="$(grep ^processor /proc/cpuinfo | wc -l)"
+    [ "$num" -gt 0 ] || num=""
+  fi
+  echo "${num:-2}"
+}
+
+#
 # Configures Ruby.
 #
 function configure_ruby()
@@ -38,7 +52,7 @@ function configure_ruby()
 function compile_ruby()
 {
 	log "Compiling ruby $RUBY_VERSION ..."
-	make
+  make --jobs $(cores)
 }
 
 #


### PR DESCRIPTION
The `cores()` function is stolen from ruby-build
(https://github.com/sstephenson/ruby-build) and should work for both Linux and
OS X.

`--jobs` is a parameter from `make`:

> Specifies the number of jobs (commands) to run simultaneously.

This allows compiling more than one file at once.
