### PR TITLE
Use sed to fetch values

### DIFF
--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -86,15 +86,13 @@ function fail()
 
 #
 # Searches a file for a key and echos the value.
-# If the key cannot be found, the third argument will be echoed.
 #
 function fetch()
 {
 	local file="$RUBY_INSTALL_DIR/$1.txt"
 	local key="$2"
-	local pair="$(grep -E "^$key: " "$file")"
 
-	echo "${pair##$key:*( )}"
+	sed -n -e "/^$key:/ { s/^$key:[ "$'\t'"]*//; p; }" "$file"
 }
 
 function install_packages()

--- a/test/fetch_test.sh
+++ b/test/fetch_test.sh
@@ -1,8 +1,15 @@
 . ./test/helper.sh
 
+RUBY_INSTALL_DIR="./test/dir"
+
 function setUp()
 {
 	RUBY=ruby
+	TAB=$'\t'
+
+	mkdir -p "$RUBY_INSTALL_DIR/$RUBY"
+	echo "1.8.7:${TAB}${TAB}1.8.7-p374" > "$RUBY_INSTALL_DIR/$RUBY/versions.txt"
+	echo "ruby-1.8.7-p374.tar.bz2: 83c92e2b57ea08f31187060098b2200b" > "$RUBY_INSTALL_DIR/$RUBY/md5.txt"
 }
 
 function test_fetch()
@@ -30,6 +37,11 @@ function test_fetch_with_unknown_key()
 	local value=$(fetch "$RUBY/versions" "$key")
 
 	assertEquals "returned the wrong value" "$expected" "$value"
+}
+
+function tearDown()
+{
+	rm -r "$RUBY_INSTALL_DIR"
 }
 
 SHUNIT_PARENT=$0 . $SHUNIT2


### PR DESCRIPTION
Uses [quoted string expansion](http://www.tldp.org/LDP/abs/html/escapingsection.html#STRQ) to include tab in the substitution regex.

Tested on `OS X 10.6.8 (Build 10K549)` and `Ubuntu 12.04.3 LTS`.

Relates to #59 and #86.
