### PR TITLE
retry curl without resume.

### DIFF
--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -133,7 +133,9 @@ function download()
 
 	case "$DOWNLOADER" in
 		wget) wget -c -O "$dest" "$url"      ;;
-		curl) curl -L -C - -o "$dest" "$url" ;;
+		curl) 
+			curl -L -C - -o "$dest" "$url" || { warn "Download failed. Retrying without resume." ; curl -L -o "$dest" "$url"; }
+			;;
 		"")
 			error "Could not find wget or curl"
 			return 1

--- a/test/download_test.sh
+++ b/test/download_test.sh
@@ -41,6 +41,16 @@ function test_download_using_curl()
 	assertTrue "did not download the file" '[[ -f "$OUTPUT" ]]'
 }
 
+function test_download_using_curl_when_file_exists()
+{
+	command -v curl >/dev/null || return
+
+	DOWNLOADER="curl" download "$URL" "$OUTPUT" 2>/dev/null
+	DOWNLOADER="curl" download "$URL" "$OUTPUT" 2>/dev/null
+
+	assertTrue "did not download the file" '[[ -f "$OUTPUT" ]]'
+}
+
 function tearDown()
 {
 	rm -f "$OUTPUT"


### PR DESCRIPTION
Fixes #74.

If a downloaded Ruby archive already exists, and the server does not support resume/byte ranges, retry curl without resume.
