### PR TITLE
Add support for openssl md5 as a md5 utility.

### DIFF
--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -29,8 +29,9 @@ fi
 #
 # Auto-detect the md5 utility.
 #
-if   command -v md5sum >/dev/null; then MD5SUM="md5sum"
-elif command -v md5    >/dev/null; then MD5SUM="md5"
+if   command -v md5sum  >/dev/null; then MD5SUM="md5sum"
+elif command -v md5     >/dev/null; then MD5SUM="md5"
+elif command -v openssl >/dev/null; then MD5SUM="openssl md5"
 fi
 
 #

--- a/test/verify_test.sh
+++ b/test/verify_test.sh
@@ -41,6 +41,15 @@ function test_verify_using_md5()
 	assertEquals "did not return the correct MD5" 0 $?
 }
 
+function test_verify_using_openssl()
+{
+	command -v openssl >/dev/null || return
+
+	MD5SUM="openssl md5" verify "$FILE" "$MD5" >/dev/null
+
+	assertEquals "did not return the correct MD5" 0 $?
+}
+
 function test_verify_with_bad_md5()
 {
 	verify "$FILE" "4101bef8794fed986e95dfb54850c68b" >/dev/null 2>/dev/null


### PR DESCRIPTION
I ran into not having a md5 utility on Mavericks so I added `openssl md5` as a possible provider. Turns out I just didn't have `md5` in my PATH for some reason. Figured I would open this pull request though just to see if there was any interest.
