### PR TITLE
Add clean before builds

### DIFF
--- a/share/ruby-install/mruby/functions.sh
+++ b/share/ruby-install/mruby/functions.sh
@@ -10,6 +10,9 @@ ruby_url="${ruby_url:-$ruby_mirror/$ruby_version/$ruby_archive}"
 #
 function compile_ruby()
 {
+	log "Cleaning mruby $ruby_version ..."
+	make clean || return $?
+
 	log "Compiling mruby $ruby_version ..."
 	make "${make_opts[@]}" || return $?
 }

--- a/share/ruby-install/rbx/functions.sh
+++ b/share/ruby-install/rbx/functions.sh
@@ -43,6 +43,9 @@ function configure_ruby()
 				    "${configure_opts[@]}" || return $?
 			;;
 	esac
+
+	log "Cleaning rubinius $ruby_version ..."
+	bundle exec rake distclean || return $?
 }
 
 #

--- a/share/ruby-install/ruby/functions.sh
+++ b/share/ruby-install/ruby/functions.sh
@@ -28,6 +28,9 @@ function configure_ruby()
 				    "${configure_opts[@]}" || return $?
 			;;
 	esac
+
+	log "Cleaning ruby $ruby_version ..."
+	make clean || return $?
 }
 
 #


### PR DESCRIPTION
I originally added a new clean_ruby step before configure_ruby. That doesn't work because Rubinius needs to bundle before you can clean, and the bundle happens in configure, which is too late. I didn't want to divide configure into two stages. This should fix #92.
