### PR TITLE
update package name for apt jre

### DIFF
--- a/share/ruby-install/jruby/dependencies.txt
+++ b/share/ruby-install/jruby/dependencies.txt
@@ -1,3 +1,3 @@
-apt: openjdk-7-jdk
+apt: openjdk-7-jre-headless
 yum: java-1.7.0-openjdk
 pacman: jre7-openjdk


### PR DESCRIPTION
openjdk-7-jre installs all kinds of GUI stuff.
This doesn't work in Docker, use the headless package instead.
