### PR TITLE
Allow installing MRI from a binary mirror

### DIFF
--- a/bin/ruby-install
+++ b/bin/ruby-install
@@ -35,9 +35,13 @@ extract_ruby   || fail "Unpacking of $ruby_archive failed!"
 download_patches || fail "Fetching patches $patches failed!"
 apply_patches  || fail "Patching $ruby $ruby_version failed!"
 cd "$src_dir/$ruby_src_dir"
-configure_ruby || fail "Configuration of $ruby $ruby_version failed!"
-clean_ruby     || fail "Cleaning $ruby $ruby_version failed!"
-compile_ruby   || fail "Compiling $ruby $ruby_version failed!"
+
+if [[ ! $binary_install -eq 1 ]]; then
+	configure_ruby || fail "Configuration of $ruby $ruby_version failed!"
+	clean_ruby     || fail "Cleaning $ruby $ruby_version failed!"
+	compile_ruby   || fail "Compiling $ruby $ruby_version failed!"
+fi
+
 install_ruby   || fail "Installation of $ruby $ruby_version failed!"
 post_install   || fail "Post-install tasks failed!"
 

--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -55,22 +55,12 @@ case "$(uname)" in
 			system_name="ubuntu"
 			system_version="$(awk -F'=' '$1=="DISTRIB_RELEASE"{print $2}' /etc/lsb-release)"
 			system_arch="$(dpkg --print-architecture)"
-		elif [[ -f /etc/lsb-release ]] && grep "DISTRIB_ID=LinuxMint" /etc/lsb-release >/dev/null; then
-			system_name="mint"
-			system_version="$(awk -F'=' '$1=="DISTRIB_RELEASE"{print $2}' /etc/lsb-release)"
-			system_arch="$(dpkg --print-architecture)"
-		elif [[ -f /etc/lsb-release ]] && grep "DISTRIB_ID=ManjaroLinux" /etc/lsb-release >/dev/null; then
-			system_name="manjaro"
-			system_version="$(awk -F'=' '$1=="DISTRIB_RELEASE"{print $2}' /etc/lsb-release)"
 		elif [[ -f /etc/altlinux-release ]]; then
 			system_name="arch"
 			system_version="libc-$(ldd --version | awk 'NR==1 {print $NF}' | awk -F. '{print $1"."$2}')"
 		elif [[ -f /etc/os-release ]] && grep "ID=opensuse" /etc/os-release >/dev/null; then
 			system_name="opensuse"
 			system_version="$(awk -F'=' '$1=="VERSION_ID"{gsub(/"/,"");print $2}' /etc/os-release)"
-		elif [[ -f /etc/SuSE-release ]]; then
-			system_name="suse"
-			system_version="$(awk -F'=' '{gsub(/ /,"")} $1~/VERSION/ {version=$2} $1~/PATCHLEVEL/ {patch=$2} END {print version"."patch}' < /etc/SuSE-release)"
 		elif [[ -f /etc/debian_version ]]; then
 			system_name="debian"
 			system_version="$(cat /etc/debian_version | awk -F. '{print $1}')"
@@ -82,18 +72,8 @@ case "$(uname)" in
 		elif [[ -f /etc/system-release ]] && grep "Amazon Linux AMI" /etc/system-release >/dev/null; then
 			system_name="amazon"
 			system_version="$(grep -Eo '[0-9\.]+' /etc/system-release | awk -F. '{print $1"."$2}')"
-		elif [[ -f /etc/sabayon-release ]]; then
-			# needs to be before gentoo
-			system_name="sabayon"
-			system_version="$(\cat /etc/sabayon-release | awk 'NR==1 {print $NF}' | awk -F. '{print $1"."$2}')"
-		elif [[ -f /etc/gentoo-release ]]; then
-			system_name="gentoo"
-			system_version="base-$(\cat /etc/gentoo-release | awk 'NR==1 {print $NF}' | awk -F. '{print $1"."$2}')"
 		elif [[ -f /etc/arch-release ]]; then
 			system_name="arch"
-			system_version="libc-$(ldd --version  | awk 'NR==1 {print $NF}' | awk -F. '{print $1"."$2}')"
-		elif [[ -f /proc/devices ]] && grep -Eo "synobios" /proc/devices >/dev/null; then
-			system_name="synology"
 			system_version="libc-$(ldd --version  | awk 'NR==1 {print $NF}' | awk -F. '{print $1"."$2}')"
 		elif [[ -f /etc/fedora-release ]]; then
 			system_name="fedora"
@@ -101,60 +81,16 @@ case "$(uname)" in
 		elif [[ -f /etc/centos-release ]]; then
 			system_name="centos"
 			system_version="$(grep -Eo '[0-9\.]+' /etc/centos-release | awk -F. '{print $1}')"
-		elif [[ -f /etc/redhat-release ]]; then
-			system_name="$(grep -Eo 'CentOS|ClearOS|Mageia|Scientific' /etc/redhat-release 2>/dev/null)" || system_name="redhat"
+		elif [[ -f /etc/redhat-release ]] && grep CentOS /etc/redhat-release >/dev/null; then
+			system_name="centos"
 			system_version="$(grep -Eo '[0-9\.]+' /etc/redhat-release  | awk -F. 'NR==1{print $1}')"
 		else
 			system_version="libc-$(ldd --version | awk 'NR==1 {print $NF}' | awk -F. '{print $1"."$2}')"
 		fi
 		;;
-	(SunOS)
-		system_name="solaris"
-		system_version="$(uname -v)"
-		system_arch="$(uname -p)"
-		if [[ "${system_version}" =~ ^joyent* ]]; then
-			system_name="smartos"
-			system_version="${system_version#* }"
-		elif [[ "${system_version}" =~ ^omnios* ]]; then
-			system_name="omnios"
-			system_version="${system_version#* }"
-		elif [[ "${system_version}" =~ ^oi* || "${system_version}" =~ ^illumos* ]]; then
-			system_name="openindiana"
-			system_version="${system_version#* }"
-		elif [[ "${system_version}" =~ Generic* ]]; then
-			system_version="10"
-		elif [[ "${system_version}" =~ 11* ]]; then
-			system_version="11"
-			# is else needed here?
-		fi
-		;;
-	(FreeBSD)
-		system_name="freebsd"
-		system_version="$(uname -r)"
-		system_version="${system_version%%-*}"
-		;;
-	(OpenBSD)
-		system_name="openbsd"
-		system_version="$(uname -r)"
-		;;
-	(DragonFly)
-		system_name="dragonfly"
-		system_version="$(uname -r)"
-		system_version="${system_version%%-*}"
-		;;
-	(NetBSD)
-		system_name="netbsd"
-		system_version="$(uname -r | awk -F. '{print $1"."$2}')"
-		;;
 	(Darwin)
 		system_name="osx"
 		system_version="$(sw_vers -productVersion | awk -F. '{print $1"."$2}')"
-		;;
-	(CYGWIN*)
-		system_name="cygwin"
-		;;
-	(MINGW*)
-		system_name="mingw"
 		;;
 esac
 system_name="${system_name//[ \/]/_}"

--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -112,28 +112,18 @@ case "$(uname)" in
 		system_name="solaris"
 		system_version="$(uname -v)"
 		system_arch="$(uname -p)"
-		if
-			[[ "${system_version}" =~ ^joyent* ]]
-		then
+		if [[ "${system_version}" =~ ^joyent* ]]; then
 			system_name="smartos"
 			system_version="${system_version#* }"
-		elif
-			[[ "${system_version}" =~ ^omnios* ]]
-		then
+		elif [[ "${system_version}" =~ ^omnios* ]]; then
 			system_name="omnios"
 			system_version="${system_version#* }"
-		elif
-			[[ "${system_version}" =~ ^oi* || "${system_version}" =~ ^illumos* ]]
-		then
+		elif [[ "${system_version}" =~ ^oi* || "${system_version}" =~ ^illumos* ]]; then
 			system_name="openindiana"
 			system_version="${system_version#* }"
-		elif
-			[[ "${system_version}" =~ Generic* ]]
-		then
+		elif [[ "${system_version}" =~ Generic* ]]; then
 			system_version="10"
-		elif
-			[[ "${system_version}" =~ 11* ]]
-		then
+		elif [[ "${system_version}" =~ 11* ]]; then
 			system_version="11"
 			# is else needed here?
 		fi

--- a/share/ruby-install/ruby/functions.sh
+++ b/share/ruby-install/ruby/functions.sh
@@ -18,10 +18,6 @@ fi
 #
 function configure_ruby()
 {
-	if [[ $binary_install -eq 1 ]]; then
-		return
-	fi
-
 	log "Configuring ruby $ruby_version ..."
 	case "$package_manager" in
 		brew)
@@ -46,10 +42,6 @@ function configure_ruby()
 #
 function clean_ruby()
 {
-	if [[ $binary_install -eq 1 ]]; then
-		return
-	fi
-
 	log "Cleaning ruby $ruby_version ..."
 	make clean || return $?
 }
@@ -59,10 +51,6 @@ function clean_ruby()
 #
 function compile_ruby()
 {
-	if [[ $binary_install -eq 1 ]]; then
-		return
-	fi
-
 	log "Compiling ruby $ruby_version ..."
 	make "${make_opts[@]}" || return $?
 }

--- a/share/ruby-install/ruby/functions.sh
+++ b/share/ruby-install/ruby/functions.sh
@@ -1,16 +1,27 @@
 #!/usr/bin/env bash
 
-ruby_version_family="${ruby_version:0:3}"
-ruby_archive="ruby-$ruby_version.tar.bz2"
-ruby_src_dir="ruby-$ruby_version"
-ruby_mirror="${ruby_mirror:-http://cache.ruby-lang.org/pub/ruby}"
-ruby_url="${ruby_url:-$ruby_mirror/$ruby_version_family/$ruby_archive}"
+if [[ $binary_install -eq 1 ]]; then
+	ruby_archive="ruby-bin-$ruby_version.tar.bz2"
+	ruby_src_dir="ruby-$ruby_version"
+	ruby_mirror="${ruby_mirror:-https://rvm.io/binaries}"
+	ruby_url="${ruby_url:-$ruby_mirror/$system_name/$system_version/$system_arch/ruby-$ruby_version.tar.bz2}"
+else
+	ruby_archive="ruby-$ruby_version.tar.bz2"
+	ruby_src_dir="ruby-$ruby_version"
+	ruby_version_family="${ruby_version:0:3}"
+	ruby_mirror="${ruby_mirror:-http://cache.ruby-lang.org/pub/ruby}"
+	ruby_url="${ruby_url:-$ruby_mirror/$ruby_version_family/$ruby_archive}"
+fi
 
 #
 # Configures Ruby.
 #
 function configure_ruby()
 {
+	if [[ $binary_install -eq 1 ]]; then
+		return
+	fi
+
 	log "Configuring ruby $ruby_version ..."
 	case "$package_manager" in
 		brew)
@@ -35,6 +46,10 @@ function configure_ruby()
 #
 function clean_ruby()
 {
+	if [[ $binary_install -eq 1 ]]; then
+		return
+	fi
+
 	log "Cleaning ruby $ruby_version ..."
 	make clean || return $?
 }
@@ -44,6 +59,10 @@ function clean_ruby()
 #
 function compile_ruby()
 {
+	if [[ $binary_install -eq 1 ]]; then
+		return
+	fi
+
 	log "Compiling ruby $ruby_version ..."
 	make "${make_opts[@]}" || return $?
 }
@@ -54,5 +73,10 @@ function compile_ruby()
 function install_ruby()
 {
 	log "Installing ruby $ruby_version ..."
-	make install || return $?
+
+	if [[ $binary_install -eq 1 ]]; then
+		cp -R "$src_dir/$ruby_src_dir" "$install_dir" || return $?
+	else
+		make install || return $?
+	fi
 }


### PR DESCRIPTION
This downloads and installs a precompiled version of MRI from an RVM-compatible mirror if `--binary` is passed

The system auto-detection is a huge mess, and probably violating the style guide (several lines longer than 80 characters). It's mostly lifted from RVM's own system detection. I don't know if you want this somewhere else (if so, where?) or if you want me to shorten the number of supported systems, just let me know and I can modify.

As for the long lines, should I just "wrap" them?

This currently just fails if `--binary` is passed and no binary build was found, since that was the easiest to implement.
