### PR TITLE
prune installation directories that no longer exists from `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION=0.4.1
 AUTHOR=postmodern
 URL=https://github.com/$(AUTHOR)/$(NAME)
 
-DIRS=etc lib bin sbin share
+DIRS=bin share
 INSTALL_DIRS=`find $(DIRS) -type d 2>/dev/null`
 INSTALL_FILES=`find $(DIRS) -type f 2>/dev/null`
 DOC_FILES=*.md *.txt


### PR DESCRIPTION
```
% find $DIRS -type d
```

Before prune:

```
find: `etc': No such file or directory
find: `lib': No such file or directory
bin
find: `sbin': No such file or directory
share
share/ruby-install
share/ruby-install/mruby
share/ruby-install/jruby
share/ruby-install/rbx
share/ruby-install/maglev
share/ruby-install/ruby
share/man
share/man/man1
```

After prune:

```
bin
share
share/man
share/man/man1
share/ruby-install
share/ruby-install/jruby
share/ruby-install/maglev
share/ruby-install/mruby
share/ruby-install/rbx
share/ruby-install/ruby
```
