### PR TITLE
Added bzip2 as a dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Installs [Ruby], [JRuby], [Rubinius], [MagLev] or [mruby].
 * [wget] or [curl]
 * `md5sum`, `md5` or `openssl md5`.
 * `tar`
+* `bzip2`
 * `patch` (if `--patch` is specified)
 * [gcc] >= 4.2 or [clang]
 


### PR DESCRIPTION
Bzip2 is an undocumented dependency.

When, for instance, installing/using ruby-install via chef-ruby-install, in some machines (docker, for instance), `bzip2` doesn't exist and ruby-install cannot be installed.
