### PR TITLE
add ruby-1.9.2-p330.tar.bz2

### DIFF
--- a/share/ruby-install/ruby/md5.txt
+++ b/share/ruby-install/ruby/md5.txt
@@ -11,6 +11,7 @@ ruby-1.9.2-p180.tar.bz2:      68510eeb7511c403b91fe5476f250538
 ruby-1.9.2-p290.tar.bz2:      096758c3e853b839dc980b183227b182
 ruby-1.9.2-p318.tar.bz2:      be431c6cbfa27e3836a06c6315717747
 ruby-1.9.2-p320.tar.bz2:      b226dfe95d92750ee7163e899b33af00
+ruby-1.9.2-p330.tar.bz2:      8ba4aaf707023e76f80fc8f455c99858
 ruby-1.9.3-p0.tar.bz2:        65401fb3194cdccd6c1175ab29b8fdb8
 ruby-1.9.3-p125.tar.bz2:      702529a7f8417ed79f628b77d8061aa5
 ruby-1.9.3-p194.tar.bz2:      2278eff4cfed3cbc0653bc73085caa34


### PR DESCRIPTION
The [final](https://www.ruby-lang.org/en/news/2014/08/19/ruby-1.9.2-p330-released/) Ruby 1.9.2 release!
