### PR TITLE
Use the secure S3 bucket for JRuby downloads

### DIFF
--- a/share/ruby-install/jruby/functions.sh
+++ b/share/ruby-install/jruby/functions.sh
@@ -2,7 +2,7 @@
 
 ruby_archive="jruby-bin-$ruby_version.tar.gz"
 ruby_src_dir="jruby-$ruby_version"
-ruby_mirror="${ruby_mirror:-http://jruby.org.s3.amazonaws.com/downloads}"
+ruby_mirror="${ruby_mirror:-https://s3.amazonaws.com/jruby.org/downloads}"
 ruby_url="${ruby_url:-$ruby_mirror/$ruby_version/$ruby_archive}"
 
 #


### PR DESCRIPTION
The JRuby team recently [tweeted](https://twitter.com/jruby/status/525726366533443584) that Ruby installers should switch to
using a new secure link over HTTPS to download JRuby artifacts. This
patch switches the Ruby mirror to the new URL!

Signed-off-by: David Celis me@davidcel.is
