### PR TITLE
Explicitly set SHELL var to ensure make invokes bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL=/bin/bash
 NAME=ruby-install
 VERSION=0.5.1
 AUTHOR=postmodern


### PR DESCRIPTION
Ran into this problem when `update`ing from Ubuntu, which uses `/bin/dash` as default shell, which does not support the fancy bash variable expansion:

```
wget -nv -N -P share/ruby-install/ruby/ https://raw.githubusercontent.com/postmodern/ruby-versions/master/ruby/{{versions,stable}.txt,checksums.{md5,sha1,sha256,sha512}}
https://raw.githubusercontent.com/postmodern/ruby-versions/master/ruby/%7B%7Bversions,stable%7D.txt,checksums.%7Bmd5,sha1,sha256,sha512%7D%7D:
2014-10-28 07:35:25 ERROR 404: Not Found.
make: *** [update] Error 8
```

Explicitly setting the shell to bash resolved this for me:  http://stackoverflow.com/questions/6681624/how-to-handle-shell-expansions-in-gnu-make-under-ubuntu
