### PR TITLE
Install libedit-dev via apt

### DIFF
--- a/share/ruby-install/rbx/dependencies.txt
+++ b/share/ruby-install/rbx/dependencies.txt
@@ -1,4 +1,4 @@
-apt: gcc g++ automake flex bison ruby1.9.1-dev llvm-dev zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev
+apt: gcc g++ automake flex bison ruby1.9.1-dev llvm-dev zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libedit-dev
 yum: gcc gcc-c++ automake flex bison ruby-devel rubygems llvm-static llvm-devel zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel
 port: openssl readline libyaml gdbm
 brew: openssl readline libyaml gdbm


### PR DESCRIPTION
LLVM 3.5 will add `-ledit` to the `config[:llvm_ldflags]` option.