### PR TITLE
Add switch to force the packager to be used.

### DIFF
--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -226,6 +226,7 @@ Options:
 	-M, --mirror URL	Alternate mirror to download the Ruby archive from
 	-u, --url URL		Alternate URL to download the Ruby archive from
 	-m, --md5 MD5		MD5 checksum of the Ruby archive
+	    --packager NAME     Alternate package manager to use instead of default.
 	    --sha1 SHA1		SHA1 checksum of the Ruby archive
 	    --sha256 SHA256	SHA256 checksum of the Ruby archive
 	    --sha512 SHA512	SHA512 checksum of the Ruby archive
@@ -267,6 +268,10 @@ function parse_options()
 				install_dir="$2"
 				shift 2
 				;;
+                        --packager)
+                                package_manager="$2"
+                                shift 2
+                                ;;
 			--system)
 				install_dir="/usr/local"
 				shift 1


### PR DESCRIPTION
I have dpkg tools installed on my Fedora machine to build Debian
packages. Using ruby-install fails here because I don't want to use
apt-get and it just so happens to be at the top of the branch
statement. This switch will allow us to override the default packager if necessary.
