### PR TITLE
Switched Travis CI badge to SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ruby-install
 
-[![Build Status](https://travis-ci.org/postmodern/ruby-install.png?branch=master)](https://travis-ci.org/postmodern/ruby-install)
+[![Build Status](https://travis-ci.org/postmodern/ruby-install.svg?branch=master)](https://travis-ci.org/postmodern/ruby-install)
 
 Installs [Ruby], [JRuby], [Rubinius], [MagLev] or [mruby].
 


### PR DESCRIPTION
This looks [a lot better](https://github.com/parndt/ruby-install/tree/02696c2204bbb80c20cdc2dff8ad100c9ac1d2bb#readme) on higher resolution displays.
