### PR TITLE
Clarify ruby installation instructions for newer Ruby releases not listed by ruby-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Installs [Ruby], [JRuby], [Rubinius], [MagLev] or [mruby].
 ## Features
 
 * Supports installing arbitrary versions.
-  * Provides a list of stable versions.
+  * Provides a fixed list of stable versions (an [update option][issue175] is planned).
 * Supports installing into `/opt/rubies/` for root and `~/.rubies/` for users
   by default.
 * Supports installing into arbitrary directories.
@@ -43,25 +43,30 @@ Installs [Ruby], [JRuby], [Rubinius], [MagLev] or [mruby].
 
 ## Synopsis
 
-List supported Rubies and their major versions:
+List supported Rubies and their known stable versions:
 
     $ ruby-install
 
-Install the current stable version of Ruby:
+For newer [unknown versions][issue198] follow the 'recently released' install steps below.
+
+Install the known current stable version of Ruby:
 
     $ ruby-install ruby
 
-Install a stable version of Ruby:
+Install a known stable version of Ruby:
 
     $ ruby-install ruby 1.9
 
-Install a specific version of Ruby:
+Install a known specific version of Ruby:
 
     $ ruby-install ruby 1.9.3-p429
 
-Install a recently released version of Ruby:
+Install a recently released version of Ruby not known by ruby-install:
 
     $ ruby-install --md5 MD5_OF_TAR_BZ2 ruby 2.3.4
+
+There are also `--sha1`, `--sha256` and `--sha512` options. Specify one or more
+checksums to validate.
 
 Install a Ruby into a specific directory:
 
@@ -173,6 +178,9 @@ Instead, please use Rubinius >= 2.1.x.
 
 -- [Sam Stephenson](https://twitter.com/sstephenson/status/334461494668443649)
 of [rbenv]
+
+[issue175]: https://github.com/postmodern/ruby-install/issues/175
+[issue198]: https://github.com/postmodern/ruby-install/issues/198
 
 [Ruby]: http://www.ruby-lang.org/
 [JRuby]: http://jruby.org/

--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -197,12 +197,18 @@ function known_rubies()
 {
 	local ruby
 
-	echo "Latest ruby versions:"
+	echo "Known stable ruby versions:"
 
 	for ruby in ${rubies[@]}; do
 		echo "  $ruby:"
 		cat "$ruby_install_dir/$ruby/stable.txt" | sed -e 's/^/    /' || return $?
 	done
+
+	echo -e "\nRecently released but unknown versions can also be installed. Eg:"
+	echo "ruby-install --md5 MD5_OF_TAR_BZ2 ruby 2.3.4"
+	echo -e "\nFor additional options:"
+	echo "ruby-install --help"
+
 }
 
 #


### PR DESCRIPTION
I've attempted to improve the documentation and language around installing newer Rubies that are not know by ruby-install. This is in commit c6fd8c4.

I've also adjusted the output when ruby-install lists known Rubies to be a little more clearer. This is in commit 7356c6a.

Now 7356c6a will mean a new release to be of benefit to users, and there may not be another release before the `--update` option in #175 is included, so you may wish to exclude this commit. I've also not run the tests on this change as I was unsure how to do so and what changes they'd leave on my system regarding file download tests. I have however looked at the `supported_rubies_test.sh` tests and can't see any issues. My changes are just textual.

This is my first pull request, so unsure exactly how everything works. I believe you can cherry pick just the documentation changes, but if you can't and require two separate pull requests just let me know and I'll create them.