### PR TITLE
Update README installation instructions to download latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ ruby-install can even be used with [Chef].
 
 ## Install
 
-    wget -O ruby-install-0.5.0.tar.gz https://github.com/postmodern/ruby-install/archive/v0.5.0.tar.gz
-    tar -xzvf ruby-install-0.5.0.tar.gz
-    cd ruby-install-0.5.0/
+    wget -O ruby-install-0.5.1.tar.gz https://github.com/postmodern/ruby-install/archive/v0.5.1.tar.gz
+    tar -xzvf ruby-install-0.5.1.tar.gz
+    cd ruby-install-0.5.1/
     sudo make install
 
 ### PGP
@@ -124,8 +124,8 @@ All releases are [PGP] signed for security. Instructions on how to import my
 PGP key can be found on my [blog][1]. To verify that a release was not tampered
 with:
 
-    wget https://raw.github.com/postmodern/ruby-install/master/pkg/ruby-install-0.5.0.tar.gz.asc
-    gpg --verify ruby-install-0.5.0.tar.gz.asc ruby-install-0.5.0.tar.gz
+    wget https://raw.github.com/postmodern/ruby-install/master/pkg/ruby-install-0.1.0.tar.gz.asc
+    gpg --verify ruby-install-0.5.1.tar.gz.asc ruby-install-0.5.1.tar.gz
 
 ### Homebrew
 


### PR DESCRIPTION
After following the old installation scripts, I was confused as to why I couldn't install ruby 2.2.0, and I imagine others have had this confusion. Updating the readme to point to the newest version would be helpful.