### PR TITLE
Warn the user when using a URL for a Ruby name

### DIFF
--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -377,4 +377,11 @@ function parse_options()
 			return 1
 			;;
 	esac
+	case "${ruby}" in
+		*:*|*/*|*@*)
+			echo "ruby-install: argument \"${ruby}\" does not look like a Ruby name"
+			return 1
+			;;
+	esac
+	return 0
 }

--- a/test/parse_options_test.sh
+++ b/test/parse_options_test.sh
@@ -139,6 +139,15 @@ function test_parse_options_with_url()
 	assertEquals "did not set \$ruby_url" "$url" "$ruby_url"
 }
 
+function test_parse_options_with_url_in_wrong_place()
+{
+	local url="http://mirror.s3.amazonaws.com/downloads/ruby-1.2.3.tar.gz"
+
+	parse_options "$url" "ruby" 2>&1
+
+	assertEquals "did not return 1" 1 $?
+}
+
 function test_parse_options_with_md5()
 {
 	local md5="5d41402abc4b2a76b9719d911017c592"


### PR DESCRIPTION
I made a mistake recently:

```
$ ruby-install --md5 06973777736d8e6bdad8dcaa469a9da3 http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.bz2
ruby-install: unsupported ruby: http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.bz2`
```

ruby-install's error message gave me the impression that I had supplied the
correct arguments but ruby-install did not know how to build the Ruby at that
URL.

With this patch, ruby-install's error message tells me what I've done wrong:

```
$ ruby-install --md5 06973777736d8e6bdad8dcaa469a9da3 http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.bz2
ruby-install: argument "http://mirror.s3.amazonaws.com/downloads/ruby-2.2.0.tar.gz" does not look like a Ruby name
```