### PR TITLE
detect correct package manager on archlinux based distros

### DIFF
--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -15,13 +15,12 @@ make_opts=()
 #
 # Auto-detect the package manager.
 #
-if   command -v pacman	>/dev/null; then package_manager="pacman"
-elif command -v yum	>/dev/null; then package_manager="yum"
+if   command -v pacman  >/dev/null; then package_manager="pacman"
+elif command -v yum     >/dev/null; then package_manager="yum"
 elif command -v apt-get >/dev/null; then package_manager="apt"
-elif command -v port	>/dev/null; then package_manager="port"
-elif command -v brew	>/dev/null; then package_manager="brew"
+elif command -v port    >/dev/null; then package_manager="port"
+elif command -v brew    >/dev/null; then package_manager="brew"
 fi
-
 #
 # Auto-detect the downloader.
 #
@@ -32,8 +31,8 @@ fi
 #
 # Only use sudo if already root.
 #
-if (( $UID == 0 )); then sudo=""
-else			 sudo="sudo"
+if (( UID == 0 )); then sudo=""
+else                    sudo="sudo"
 fi
 
 #
@@ -77,7 +76,7 @@ function error()
 #
 function fail()
 {
-	error "$*"
+	error "$@"
 	exit -1
 }
 
@@ -101,22 +100,22 @@ function fetch()
 function install_packages()
 {
 	case "$package_manager" in
-		apt)	$sudo apt-get install -y $* || return $? ;;
-		yum)	$sudo yum install -y $* || return $?	 ;;
-		port)	$sudo port install $* || return $?		 ;;
+		apt)	$sudo apt-get install -y "$@" || return $? ;;
+		yum)	$sudo yum install -y "$@" || return $?     ;;
+		port)   $sudo port install "$@" || return $?       ;;
 		brew)
 			local brew_owner="$(/usr/bin/stat -f %Su "$(command -v brew)")"
-			sudo -u "$brew_owner" brew install $* ||
-			sudo -u "$brew_owner" brew upgrade $* || return $?
+			sudo -u "$brew_owner" brew install "$@" ||
+			sudo -u "$brew_owner" brew upgrade "$@" || return $?
 			;;
 		pacman)
-			local missing_pkgs="$(pacman -T $*)"
+			local missing_pkgs=($(pacman -T "$@"))
 
-			if [[ -n "$missing_pkgs" ]]; then
-				$sudo pacman -S $missing_pkgs || return $?
+			if (( ${#missing_pkgs[@]} > 0 )); then
+				$sudo pacman -S "${missing_pkgs[@]}" || return $?
 			fi
 			;;
-		"") warn "Could not determine Package Manager. Proceeding anyway." ;;
+		"")	warn "Could not determine Package Manager. Proceeding anyway." ;;
 	esac
 }
 
@@ -132,7 +131,7 @@ function download()
 	[[ -f "$dest" ]] && return
 
 	case "$downloader" in
-		wget) wget -c -O "$dest.part" "$url" || return $?		  ;;
+		wget) wget -c -O "$dest.part" "$url" || return $?         ;;
 		curl) curl -f -L -C - -o "$dest.part" "$url" || return $? ;;
 		"")
 			error "Could not find wget or curl"
@@ -153,7 +152,7 @@ function extract()
 
 	case "$archive" in
 		*.tgz|*.tar.gz) tar -xzf "$archive" -C "$dest" || return $? ;;
-		*.tbz|*.tbz2|*.tar.bz2) tar -xjf "$archive" -C "$dest" || return $? ;;
+		*.tbz|*.tbz2|*.tar.bz2)	tar -xjf "$archive" -C "$dest" || return $? ;;
 		*.zip) unzip "$archive" -d "$dest" || return $? ;;
 		*)
 			error "Unknown archive format: $archive"
@@ -176,7 +175,7 @@ function load_ruby()
 
 	local absolute_version="$(
 	  resolve_version "$ruby_version" \
-				  "$ruby_dir/versions.txt" \
+		          "$ruby_dir/versions.txt" \
 			  "$ruby_dir/stable.txt"
 	)"
 
@@ -199,9 +198,9 @@ function known_rubies()
 
 	echo "Latest ruby versions:"
 
-	for ruby in ${rubies[@]}; do
-		echo "	$ruby:"
-		cat "$ruby_install_dir/$ruby/stable.txt" | sed -e 's/^/    /' || return $?
+	for ruby in "${rubies[@]}"; do
+		echo "  $ruby:"
+		sed -e 's/^/    /' "$ruby_install_dir/$ruby/stable.txt" || return $?
 	done
 }
 
@@ -217,8 +216,8 @@ Options:
 
 	-r, --rubies-dir DIR	Directory that contains other installed Rubies
 	-i, --install-dir DIR	Directory to install Ruby into
-		--prefix DIR		Alias for -i DIR
-		--system		Alias for -i /usr/local
+	    --prefix DIR        Alias for -i DIR
+	    --system		Alias for -i /usr/local
 	-s, --src-dir DIR	Directory to download source-code into
 	-c, --cleanup		Remove archive and unpacked source-code after installation
 	-j, --jobs JOBS		Number of jobs to run in parallel when compiling
@@ -226,14 +225,14 @@ Options:
 	-M, --mirror URL	Alternate mirror to download the Ruby archive from
 	-u, --url URL		Alternate URL to download the Ruby archive from
 	-m, --md5 MD5		MD5 checksum of the Ruby archive
-		--sha1 SHA1		SHA1 checksum of the Ruby archive
-		--sha256 SHA256 SHA256 checksum of the Ruby archive
-		--sha512 SHA512 SHA512 checksum of the Ruby archive
+	    --sha1 SHA1		SHA1 checksum of the Ruby archive
+	    --sha256 SHA256	SHA256 checksum of the Ruby archive
+	    --sha512 SHA512	SHA512 checksum of the Ruby archive
 	--no-download		Use the previously downloaded Ruby archive
 	--no-verify		Do not verify the downloaded Ruby archive
 	--no-extract		Do not re-extract the downloaded Ruby archive
 	--no-install-deps	Do not install build dependencies before installing Ruby
-	--no-reinstall		Skip installation if another Ruby is detected in same location
+	--no-reinstall  	Skip installation if another Ruby is detected in same location
 	-V, --version		Prints the version
 	-h, --help		Prints this message
 
@@ -378,5 +377,3 @@ function parse_options()
 			;;
 	esac
 }
-
-# vim: ts=8 sw=8 noexpandtab

--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -15,11 +15,11 @@ make_opts=()
 #
 # Auto-detect the package manager.
 #
-if   command -v apt-get >/dev/null; then package_manager="apt"
-elif command -v yum     >/dev/null; then package_manager="yum"
-elif command -v port    >/dev/null; then package_manager="port"
-elif command -v brew    >/dev/null; then package_manager="brew"
-elif command -v pacman  >/dev/null; then package_manager="pacman"
+if   command -v pacman	>/dev/null; then package_manager="pacman"
+elif command -v yum	>/dev/null; then package_manager="yum"
+elif command -v apt-get >/dev/null; then package_manager="apt"
+elif command -v port	>/dev/null; then package_manager="port"
+elif command -v brew	>/dev/null; then package_manager="brew"
 fi
 
 #
@@ -33,7 +33,7 @@ fi
 # Only use sudo if already root.
 #
 if (( $UID == 0 )); then sudo=""
-else                     sudo="sudo"
+else			 sudo="sudo"
 fi
 
 #
@@ -102,8 +102,8 @@ function install_packages()
 {
 	case "$package_manager" in
 		apt)	$sudo apt-get install -y $* || return $? ;;
-		yum)	$sudo yum install -y $* || return $?     ;;
-		port)   $sudo port install $* || return $?       ;;
+		yum)	$sudo yum install -y $* || return $?	 ;;
+		port)	$sudo port install $* || return $?		 ;;
 		brew)
 			local brew_owner="$(/usr/bin/stat -f %Su "$(command -v brew)")"
 			sudo -u "$brew_owner" brew install $* ||
@@ -116,7 +116,7 @@ function install_packages()
 				$sudo pacman -S $missing_pkgs || return $?
 			fi
 			;;
-		"")	warn "Could not determine Package Manager. Proceeding anyway." ;;
+		"") warn "Could not determine Package Manager. Proceeding anyway." ;;
 	esac
 }
 
@@ -132,7 +132,7 @@ function download()
 	[[ -f "$dest" ]] && return
 
 	case "$downloader" in
-		wget) wget -c -O "$dest.part" "$url" || return $?         ;;
+		wget) wget -c -O "$dest.part" "$url" || return $?		  ;;
 		curl) curl -f -L -C - -o "$dest.part" "$url" || return $? ;;
 		"")
 			error "Could not find wget or curl"
@@ -153,7 +153,7 @@ function extract()
 
 	case "$archive" in
 		*.tgz|*.tar.gz) tar -xzf "$archive" -C "$dest" || return $? ;;
-		*.tbz|*.tbz2|*.tar.bz2)	tar -xjf "$archive" -C "$dest" || return $? ;;
+		*.tbz|*.tbz2|*.tar.bz2) tar -xjf "$archive" -C "$dest" || return $? ;;
 		*.zip) unzip "$archive" -d "$dest" || return $? ;;
 		*)
 			error "Unknown archive format: $archive"
@@ -176,7 +176,7 @@ function load_ruby()
 
 	local absolute_version="$(
 	  resolve_version "$ruby_version" \
-		          "$ruby_dir/versions.txt" \
+				  "$ruby_dir/versions.txt" \
 			  "$ruby_dir/stable.txt"
 	)"
 
@@ -200,7 +200,7 @@ function known_rubies()
 	echo "Latest ruby versions:"
 
 	for ruby in ${rubies[@]}; do
-		echo "  $ruby:"
+		echo "	$ruby:"
 		cat "$ruby_install_dir/$ruby/stable.txt" | sed -e 's/^/    /' || return $?
 	done
 }
@@ -217,8 +217,8 @@ Options:
 
 	-r, --rubies-dir DIR	Directory that contains other installed Rubies
 	-i, --install-dir DIR	Directory to install Ruby into
-	    --prefix DIR        Alias for -i DIR
-	    --system		Alias for -i /usr/local
+		--prefix DIR		Alias for -i DIR
+		--system		Alias for -i /usr/local
 	-s, --src-dir DIR	Directory to download source-code into
 	-c, --cleanup		Remove archive and unpacked source-code after installation
 	-j, --jobs JOBS		Number of jobs to run in parallel when compiling
@@ -226,14 +226,14 @@ Options:
 	-M, --mirror URL	Alternate mirror to download the Ruby archive from
 	-u, --url URL		Alternate URL to download the Ruby archive from
 	-m, --md5 MD5		MD5 checksum of the Ruby archive
-	    --sha1 SHA1		SHA1 checksum of the Ruby archive
-	    --sha256 SHA256	SHA256 checksum of the Ruby archive
-	    --sha512 SHA512	SHA512 checksum of the Ruby archive
+		--sha1 SHA1		SHA1 checksum of the Ruby archive
+		--sha256 SHA256 SHA256 checksum of the Ruby archive
+		--sha512 SHA512 SHA512 checksum of the Ruby archive
 	--no-download		Use the previously downloaded Ruby archive
 	--no-verify		Do not verify the downloaded Ruby archive
 	--no-extract		Do not re-extract the downloaded Ruby archive
 	--no-install-deps	Do not install build dependencies before installing Ruby
-	--no-reinstall  	Skip installation if another Ruby is detected in same location
+	--no-reinstall		Skip installation if another Ruby is detected in same location
 	-V, --version		Prints the version
 	-h, --help		Prints this message
 
@@ -378,3 +378,5 @@ function parse_options()
 			;;
 	esac
 }
+
+# vim: ts=8 sw=8 noexpandtab


### PR DESCRIPTION
on archlinux based distros, one can have multiple package managers
installed. There are AUR pkgs available for homebrew, yum, apt and
so on.
This allows for someone in a archlinux box to build packages for others
distributions, or to simply install them when they don't conflict
with OS files, examples are packages that install into /opt/<pkg>

The previous detection method would look for apt, yum and would set
the packager command to match whatever it found first.
My archlinux box has yum, brew, however the correct package manager
is pacman. A quickfix is to search for pacman first and then the
others.
Usually EL or Debian based boxes do not have 'brew', 'pacman' or
other package managers installed or available as a package.

*Works on my machine*