### PR TITLE
Replace insecure ruby version number.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Install a stable version of Ruby:
 
 Install a specific version of Ruby:
 
-    $ ruby-install ruby 2.2.1
+    $ ruby-install ruby 2.2.2
 
 Install a recently released version of Ruby:
 
@@ -73,7 +73,7 @@ Install a Ruby into a specific `rubies` directory:
 
 Install a Ruby into `/usr/local`:
 
-    $ ruby-install --system ruby 2.2.1
+    $ ruby-install --system ruby 2.2.2
 
 Install a Ruby from an official site with directly download:
 
@@ -89,25 +89,25 @@ Install a Ruby with a specific patch:
 
 Install a Ruby with a specific C compiler:
 
-    $ ruby-install ruby 2.2.1 -- CC=gcc-4.9
+    $ ruby-install ruby 2.2.2 -- CC=gcc-4.9
 
 Install a Ruby with specific configuration:
 
-    $ ruby-install ruby 2.2.1 -- --enable-shared --enable-dtrace CFLAGS="-O3"
+    $ ruby-install ruby 2.2.2 -- --enable-shared --enable-dtrace CFLAGS="-O3"
 
 Uninstall a Ruby version:
 
-    $ rm -rf ~/.rubies/ruby-2.2.1
+    $ rm -rf ~/.rubies/ruby-2.2.2
 
 ### Integration
 
 Using ruby-install with [RVM]:
 
-    $ ruby-install --rubies-dir ~/.rvm/rubies ruby 2.2.1
+    $ ruby-install --rubies-dir ~/.rvm/rubies ruby 2.2.2
 
 Using ruby-install with [rbenv]:
 
-    $ ruby-install --install-dir ~/.rbenv/versions/2.2.1 ruby 2.2.1
+    $ ruby-install --install-dir ~/.rbenv/versions/2.2.2 ruby 2.2.2
 
 ruby-install can even be used with [Chef].
 
@@ -155,7 +155,7 @@ installed. OS X users can install GCC via [homebrew]:
 
 And run ruby-install again:
 
-    ruby-install ruby 2.2.1 -- CC=gcc-4.9
+    ruby-install ruby 2.2.2 -- CC=gcc-4.9
 
 ### Rubinius
 

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ Install a Ruby into `/usr/local`:
 
 Install a Ruby from an official site with directly download:
 
-    $ ruby-install -M https://ftp.ruby-lang.org/pub/ruby ruby 2.0.0-p643
+    $ ruby-install -M https://ftp.ruby-lang.org/pub/ruby ruby 2.0.0-p645
 
 Install a Ruby from a mirror:
 
-    $ ruby-install -M http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby ruby 2.0.0-p643
+    $ ruby-install -M http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby ruby 2.0.0-p645
 
 Install a Ruby with a specific patch:
 

--- a/doc/man/ruby-install.1.md
+++ b/doc/man/ruby-install.1.md
@@ -110,11 +110,11 @@ Install a latest version of Ruby:
 
 Install a specific version of Ruby:
 
-    $ ruby-install ruby 2.2.1
+    $ ruby-install ruby 2.2.2
 
 Install a Ruby into a specific directory:
 
-    $ ruby-install --system ruby 2.2.1
+    $ ruby-install --system ruby 2.2.2
 
 Install a Ruby from an official site with directly download:
 
@@ -130,21 +130,21 @@ Install a Ruby with a specific patch:
 
 Install a Ruby with specific configuration:
 
-    $ ruby-install ruby 2.2.1 -- --enable-shared --enable-dtrace CFLAGS="-O3"
+    $ ruby-install ruby 2.2.2 -- --enable-shared --enable-dtrace CFLAGS="-O3"
 
 Using ruby-install with [RVM]:
 
-    $ ruby-install --rubies-dir ~/.rvm/rubies ruby 2.2.1
+    $ ruby-install --rubies-dir ~/.rvm/rubies ruby 2.2.2
 
 Using ruby-install with [rbenv]:
 
-    $ ruby-install -i ~/.rbenv/versions/2.2.1 ruby 2.2.1
+    $ ruby-install -i ~/.rbenv/versions/2.2.2 ruby 2.2.2
 
 ## FILES
 
 */usr/local/src*
 	Default root user source directory.
-    
+
 *~/src*
 	Default non-root user source directory.
 

--- a/doc/man/ruby-install.1.md
+++ b/doc/man/ruby-install.1.md
@@ -118,11 +118,11 @@ Install a Ruby into a specific directory:
 
 Install a Ruby from an official site with directly download:
 
-    $ ruby-install -M https://ftp.ruby-lang.org/pub/ruby ruby 2.0.0-p643
+    $ ruby-install -M https://ftp.ruby-lang.org/pub/ruby ruby 2.0.0-p645
 
 Install a Ruby from a mirror:
 
-    $ ruby-install -M http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby ruby 2.0.0-p643
+    $ ruby-install -M http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby ruby 2.0.0-p645
 
 Install a Ruby with a specific patch:
 


### PR DESCRIPTION
Since 2.2.2 is now out, and 2.2.1 is insecure, let's help the copy/pasters!

https://www.ruby-lang.org/en/news/2015/04/13/ruby-openssl-hostname-matching-vulnerability/

I'm not sure if you want small doc patches in a PR like this, but in case this makes it easy/faster to roll out the change, here you go! Let me know if you'd like any edits.

Thanks for the great project! 