### PR TITLE
pacman: use llvm35 dependency for rbx install

### DIFF
--- a/share/ruby-install/rbx/dependencies.txt
+++ b/share/ruby-install/rbx/dependencies.txt
@@ -2,4 +2,4 @@ apt: gcc g++ automake flex bison ruby1.9.1-dev llvm-dev zlib1g-dev libyaml-dev l
 yum: gcc gcc-c++ automake flex bison ruby-devel rubygems llvm-static llvm-devel zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel
 port: openssl readline libyaml gdbm
 brew: openssl readline libyaml gdbm
-pacman: gcc automake flex bison ruby llvm zlib libyaml openssl gdbm readline ncurses
+pacman: gcc automake flex bison ruby llvm35 zlib libyaml openssl gdbm readline ncurses


### PR DESCRIPTION
Rbx needs llvm 3.0 - 3.5, so we lock in the pacman dependemcy on the llvm35 package.