### PR TITLE
Add support for Fink on Mac OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Installs [Ruby], [JRuby], [Rubinius], [MagLev] or [mruby].
   * [pacman]
   * [macports]
   * [brew]
+  * [fink]
 * Has tests.
 
 ## Anti-Features
@@ -199,6 +200,7 @@ of [rbenv]
 [pacman]: https://wiki.archlinux.org/index.php/Pacman
 [macports]: https://www.macports.org/
 [brew]: http://brew.sh
+[fink]: http://www.finkproject.org/
 
 [bash]: http://www.gnu.org/software/bash/
 [wget]: http://www.gnu.org/software/wget/

--- a/share/ruby-install/mruby/dependencies.txt
+++ b/share/ruby-install/mruby/dependencies.txt
@@ -3,4 +3,5 @@ dnf: gcc make bison
 yum: gcc make bison
 port: bison
 brew: bison
+fink: bison
 pacman: gcc make bison

--- a/share/ruby-install/rbx/dependencies.txt
+++ b/share/ruby-install/rbx/dependencies.txt
@@ -3,4 +3,5 @@ dnf: gcc gcc-c++ automake flex bison ruby-devel rubygems llvm-static llvm-devel 
 yum: gcc gcc-c++ automake flex bison ruby-devel rubygems llvm-static llvm-devel libedit-devel zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel
 port: openssl readline libyaml gdbm
 brew: openssl readline libyaml gdbm
+fink: openssl readline6 libyaml gdbm4
 pacman: gcc automake flex bison ruby llvm35 libedit zlib libyaml openssl gdbm readline ncurses

--- a/share/ruby-install/rbx/functions.sh
+++ b/share/ruby-install/rbx/functions.sh
@@ -33,6 +33,9 @@ function configure_ruby()
 		brew)
 			opt_dir="$(brew --prefix openssl):$(brew --prefix readline):$(brew --prefix libyaml):$(brew --prefix gdbm)"
 			;;
+		fink)
+			opt_dir="/sw"
+			;;
 		port)
 			opt_dir="/opt/local"
 			;;

--- a/share/ruby-install/ruby/dependencies.txt
+++ b/share/ruby-install/ruby/dependencies.txt
@@ -3,4 +3,5 @@ dnf: gcc automake zlib-devel libyaml-devel openssl-devel gdbm-devel readline-dev
 yum: gcc automake zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel libffi-devel
 port: openssl readline libyaml gdbm libffi
 brew: openssl readline libyaml gdbm libffi
+fink: openssl readline6 libyaml gdbm4 libffi6
 pacman: gcc make zlib ncurses openssl readline libyaml gdbm libffi

--- a/share/ruby-install/ruby/functions.sh
+++ b/share/ruby-install/ruby/functions.sh
@@ -23,6 +23,9 @@ function configure_ruby()
 		brew)
 			opt_dir="$(brew --prefix openssl):$(brew --prefix readline):$(brew --prefix libyaml):$(brew --prefix gdbm)"
 			;;
+		fink)
+			opt_dir="/sw"
+			;;
 		port)
 			opt_dir="/opt/local"
 			;;

--- a/share/ruby-install/util.sh
+++ b/share/ruby-install/util.sh
@@ -3,7 +3,8 @@
 #
 # Auto-detect the package manager.
 #
-if   command -v apt-get >/dev/null; then package_manager="apt"
+if   command -v fink     >/dev/null; then package_manager="fink" # fink uses apt, so check for it before apt
+elif command -v apt-get >/dev/null; then package_manager="apt"
 elif command -v dnf     >/dev/null; then package_manager="dnf"
 elif command -v yum     >/dev/null; then package_manager="yum"
 elif command -v port    >/dev/null; then package_manager="port"
@@ -93,6 +94,7 @@ function install_packages()
 		apt)	$sudo apt-get install -y "$@" || return $? ;;
 		dnf|yum)$sudo $package_manager install -y "$@" || return $?     ;;
 		port)   $sudo port install "$@" || return $?       ;;
+		fink)         fink install "$@" || return $? ;;
 		brew)
 			local brew_owner="$(/usr/bin/stat -f %Su "$(command -v brew)")"
 			sudo -u "$brew_owner" brew install "$@" ||

--- a/test/util-tests/variables_test.sh
+++ b/test/util-tests/variables_test.sh
@@ -39,6 +39,13 @@ function test_package_manager_with_homebrew()
 	assertEquals "did not detect homebrew" "brew" "$package_manager" 
 }
 
+function test_package_manager_with_fink()
+{
+	command -v fink >/dev/null || return
+
+	assertEquals "did not detect Fink" "fink" "$package_manager" 
+}
+
 function test_downloader_with_wget()
 {
 	command -v wget >/dev/null || return


### PR DESCRIPTION
This PR adds support for the Fink package manager on Mac OS X.
