### PR TITLE
Specify full version when installing ruby 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Install the latest version of Ruby:
 
 Install a stable version of Ruby:
 
-    $ ruby-install ruby 2.3
+    $ ruby-install ruby 2.3.0
 
 Install a specific version of Ruby:
 


### PR DESCRIPTION
#### Problem

The instructions in the README currently advise

> Install a stable version of Ruby:
  ```shell
  $ ruby-install ruby 2.3
  ```

yet this fails ATTOW:
> Download of http://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.tar.bz2 failed!

#### Solution

To avoid confusion, suggest using the full `2.3.0` version.