### PR TITLE
Run brew via absolute path

### DIFF
--- a/share/ruby-install/util.sh
+++ b/share/ruby-install/util.sh
@@ -95,8 +95,8 @@ function install_packages()
 		port)   $sudo port install "$@" || return $?       ;;
 		brew)
 			local brew_owner="$(/usr/bin/stat -f %Su "$(command -v brew)")"
-			sudo -u "$brew_owner" brew install "$@" ||
-			sudo -u "$brew_owner" brew upgrade "$@" || return $?
+			sudo -u "$brew_owner" $(which brew) install "$@" ||
+			sudo -u "$brew_owner" $(which brew) upgrade "$@" || return $?
 			;;
 		pacman)
 			local missing_pkgs=($(pacman -T "$@"))


### PR DESCRIPTION
`sudo -u "$brew_owner" brew` fails if brew isn't in the system PATH. (At least on OS X, sudo seems to have special treatment of PATH; even `-E` doesn't preserve it.)

To work around this, figure out the full path to brew before the sudo call.
