### PR TITLE
Add example of installing a remote binary build

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Install a Ruby from a mirror:
 
     $ ruby-install -M http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby ruby 2.0.0-p645
 
+Install a Ruby from a remote tarball:
+
+    $ ruby-install -u http://ci.jruby.org/snapshots/master/jruby-bin-9.1.0.0-SNAPSHOT.tar.gz jruby 9.1.0.0-SNAPSHOT
+
 Install a Ruby with a specific patch:
 
     $ ruby-install -p https://raw.github.com/gist/4136373/falcon-gc.diff ruby 1.9.3-p551

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Install a Ruby from a mirror:
 
 Install a Ruby from a remote tarball:
 
-    $ ruby-install -u http://ci.jruby.org/snapshots/master/jruby-bin-9.1.0.0-SNAPSHOT.tar.gz jruby 9.1.0.0-SNAPSHOT
+    $ ruby-install -u https://s3.amazonaws.com/jruby.org/downloads/9.0.5.0/jruby-bin-9.0.5.0.tar.gz jruby 9.0.5.0
 
 Install a Ruby with a specific patch:
 


### PR DESCRIPTION
This also illustrates how to install snapshots as an alternative to installing trunk/HEAD.