### PR TITLE
Avoid copying into subdirectory in reinstall

### DIFF
--- a/share/ruby-install/jruby/functions.sh
+++ b/share/ruby-install/jruby/functions.sh
@@ -11,7 +11,7 @@ ruby_url="${ruby_url:-$ruby_mirror/$ruby_version/$ruby_archive}"
 function install_ruby()
 {
 	log "Installing jruby $ruby_version ..."
-	cp -R "$src_dir/$ruby_dir_name" "$install_dir" || return $?
+	cp -R "$src_dir/$ruby_dir_name" "$rubies_dir/" || return $?
 }
 
 #

--- a/share/ruby-install/jruby/functions.sh
+++ b/share/ruby-install/jruby/functions.sh
@@ -11,7 +11,7 @@ ruby_url="${ruby_url:-$ruby_mirror/$ruby_version/$ruby_archive}"
 function install_ruby()
 {
 	log "Installing jruby $ruby_version ..."
-	cp -R "$src_dir/$ruby_dir_name" "$rubies_dir/" || return $?
+	cp -R "$src_dir/$ruby_dir_name/*" "$install_dir/" || return $?
 }
 
 #


### PR DESCRIPTION
Fix for reinstalling a JRuby tarball.  The extracted directory was copied into an earlier install if present.

Came about after discussion in https://github.com/postmodern/ruby-install/pull/262#issuecomment-203615464 .

I have tested installing with no `~/.rubies`, no previous install, and with a previous install of the same JRuby version.
