### PR TITLE
Update apt llvm-dev in rbx dependencies.

### DIFF
--- a/share/ruby-install/rbx/dependencies.txt
+++ b/share/ruby-install/rbx/dependencies.txt
@@ -1,4 +1,4 @@
-apt: gcc g++ automake flex bison ruby1.9.1-dev llvm-3.5-dev libedit-dev zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev
+apt: gcc g++ automake flex bison ruby1.9.1-dev llvm-dev libedit-dev zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev
 dnf: gcc gcc-c++ automake flex bison ruby-devel rubygems llvm-static llvm-devel libedit-devel zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel
 yum: gcc gcc-c++ automake flex bison ruby-devel rubygems llvm-static llvm-devel libedit-devel zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel
 port: openssl readline libyaml gdbm


### PR DESCRIPTION
This updates the apt section of the rbx dependencies.txt to use a more generic llvm-dev, to allow for non-broken dependencies on Debian 8.0 Jessie and Ubuntu 16.04 LTS. (I have only tested this on Debian 8.0 Jessie via apt-get install llvm-dev (which falls back to the default llvm-3.5-dev), but if you want I can test it on Debian Jessie and Ubuntu 16.04 vagrant images).