### PR TITLE
Include automake for OSX dependencies

### DIFF
--- a/share/ruby-install/ruby/dependencies.txt
+++ b/share/ruby-install/ruby/dependencies.txt
@@ -1,6 +1,6 @@
 apt: build-essential zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev
 dnf: gcc automake zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel libffi-devel
 yum: gcc automake zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel libffi-devel
-port: openssl readline libyaml gdbm libffi
-brew: openssl readline libyaml gdbm libffi
+port: automake openssl readline libyaml gdbm libffi
+brew: automake openssl readline libyaml gdbm libffi
 pacman: gcc make zlib ncurses openssl readline libyaml gdbm libffi


### PR DESCRIPTION
Updates OSX dependency list to include `automake` for both `port `and `brew` package managers.

This was added as a requirement in c1d7dde where if a `configure` script was missing, or was older than the associated `configure.in` file, `autoreconf` would be executed to build the `configure` file.

Figured this would be better to have the extra dependency, even though it might not get used, instead of trying to find some hacky way of installing it on demand.  It looks like we already include this for `yum` and `dnf`, so figured I wasn't stepping too far out into left field with this one.