### PR TITLE
requires sudo or root

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Installs [Ruby], [JRuby], [Rubinius], [MagLev] or [mruby].
 
 ## Requirements
 
+* sudo or root access
 * [bash] >= 3.x
 * [wget] > 1.12 or [curl]
 * `md5sum`, `md5` or `openssl md5`.


### PR DESCRIPTION
the instructions in the README, when followed, run a script that runs 'sudo' to install dependencies. this doesnt work if you dont have sudo or root access.