### PR TITLE
Use default-jdk virtual package for apt

### DIFF
--- a/share/ruby-install/jruby/dependencies.txt
+++ b/share/ruby-install/jruby/dependencies.txt
@@ -1,4 +1,4 @@
-apt: openjdk-7-jdk
+apt: default-jdk
 dnf: java-openjdk
 yum: java-openjdk
 pacman: jre7-openjdk


### PR DESCRIPTION
As per #276, Ubuntu 16.04 (Xenial) needs a newer jdk version as the openjdk-7-jdk package is no longer supported. Using the default-jdk package provides this and is available in the following Ubuntu versions:

* trusty (14.04LTS)
* xenial (16.04LTS)
* artful
* bionic

reference: https://packages.ubuntu.com/default-jdk