### PR TITLE
Add TruffleRuby to ruby-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/postmodern/ruby-install.svg?branch=master)](https://travis-ci.org/postmodern/ruby-install)
 
-Installs [Ruby], [JRuby], [Rubinius] or [mruby].
+Installs [Ruby], [JRuby], [Rubinius], [TruffleRuby] or [mruby].
 
 ## Features
 
@@ -200,6 +200,7 @@ of [rbenv]
 [Ruby]: http://www.ruby-lang.org/
 [JRuby]: http://jruby.org/
 [Rubinius]: http://rubini.us/
+[TruffleRuby]: https://github.com/oracle/truffleruby
 [mruby]: https://github.com/mruby/mruby#readme
 
 [apt]: http://wiki.debian.org/Apt

--- a/doc/man/ruby-install.1.md
+++ b/doc/man/ruby-install.1.md
@@ -6,7 +6,7 @@
 
 ## DESCRIPTION
 
-Installs Ruby, JRuby, Rubinius or mruby.
+Installs Ruby, JRuby, Rubinius, TruffleRuby or mruby.
 
 https://github.com/postmodern/ruby-install#readme
 

--- a/homebrew/ruby-install.rb
+++ b/homebrew/ruby-install.rb
@@ -1,5 +1,5 @@
 class RubyInstall < Formula
-  desc "Install Ruby, JRuby, Rubinius or mruby"
+  desc "Install Ruby, JRuby, Rubinius, TruffleRuby or mruby"
   homepage "https://github.com/postmodern/ruby-install#readme"
   url "https://github.com/postmodern/ruby-install/archive/v0.6.1.tar.gz"
   sha256 "b3adf199f8cd8f8d4a6176ab605db9ddd8521df8dbb2212f58f7b8273ed85e73"

--- a/rpm/ruby-install.spec
+++ b/rpm/ruby-install.spec
@@ -6,7 +6,7 @@
 
 BuildRoot: %{buildroot}
 Source0: https://github.com/postmodern/%{name}/archive/v%{version}.tar.gz
-Summary: Installs Ruby, JRuby, Rubinius or mruby
+Summary: Installs Ruby, JRuby, Rubinius, TruffleRuby or mruby
 Name: %{name}
 Version: %{version}
 Release: %{release}
@@ -17,7 +17,7 @@ BuildArch: noarch
 Requires: bash, wget > 1.12, tar, bzip2, patch
 
 %description
-Installs Ruby, JRuby, Rubinius or mruby
+Installs Ruby, JRuby, Rubinius, TruffleRuby or mruby
 
 %prep
 %setup -q

--- a/setup.sh
+++ b/setup.sh
@@ -4,3 +4,4 @@ sudo make install
 ruby-install ruby
 ruby-install jruby
 ruby-install rubinius
+ruby-install truffleruby

--- a/share/man/man1/ruby-install.1
+++ b/share/man/man1/ruby-install.1
@@ -8,7 +8,7 @@
 .SH DESCRIPTION
 .LP
 .PP
-Installs Ruby, JRuby, Rubinius or mruby\.
+Installs Ruby, JRuby, Rubinius, TruffleRuby or mruby\.
 .LP
 .PP
 https:\[sl]\[sl]github\.com\[sl]postmodern\[sl]ruby\-install\[sh]readme

--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -6,7 +6,7 @@ ruby_install_version="0.6.1"
 ruby_install_dir="${BASH_SOURCE[0]%/*}"
 ruby_install_cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/ruby-install"
 
-rubies=(ruby jruby rbx mruby)
+rubies=(ruby jruby rbx truffleruby mruby)
 patches=()
 configure_opts=()
 make_opts=()

--- a/share/ruby-install/truffleruby/dependencies.txt
+++ b/share/ruby-install/truffleruby/dependencies.txt
@@ -1,0 +1,8 @@
+apt: zlib1g-dev libssl-dev clang llvm make
+dnf: zlib-devel openssl-devel clang llvm make
+yum: zlib-devel openssl-devel clang llvm make
+port: openssl llvm-4.0
+brew: openssl llvm@4
+pacman: zlib openssl llvm make
+zypper: zlib-devel libopenssl-devel llvm4 make
+pkg: openssl llvm40

--- a/share/ruby-install/truffleruby/dependencies.txt
+++ b/share/ruby-install/truffleruby/dependencies.txt
@@ -3,6 +3,6 @@ dnf: zlib-devel openssl-devel clang llvm make
 yum: zlib-devel openssl-devel clang llvm make
 port: openssl llvm-4.0
 brew: openssl llvm@4
-pacman: zlib openssl llvm make
-zypper: zlib-devel libopenssl-devel llvm4 make
-pkg: openssl llvm40
+pacman: zlib openssl clang llvm make
+zypper: zlib-devel libopenssl-devel llvm-clang llvm make
+pkg: openssl llvm-devel

--- a/share/ruby-install/truffleruby/functions.sh
+++ b/share/ruby-install/truffleruby/functions.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Check platform
+case $(uname) in
+	Linux) platform=linux ;;
+	Darwin) platform=macos ;;
+	*) fail "unknown platform $(uname)" ;;
+esac
+
+# Check architecture
+case $(uname -m) in
+	x86_64) arch=amd64 ;;
+	*) fail "unknown architecture $(uname -m)" ;;
+esac
+
+ruby_dir_name="truffleruby-$ruby_version-$platform-$arch"
+ruby_archive="$ruby_dir_name.tar.gz"
+ruby_mirror="${ruby_mirror:-https://github.com/oracle/truffleruby/releases/download}"
+ruby_url="${ruby_url:-$ruby_mirror/vm-$ruby_version/$ruby_archive}"
+
+#
+# Install TruffleRuby into $install_dir.
+#
+function install_ruby()
+{
+	log "Installing truffleruby $ruby_version ..."
+	cp -R "$src_dir/$ruby_dir_name" "$install_dir" || return $?
+}
+
+#
+# Post-install tasks.
+#
+function post_install()
+{
+	log "Running truffleruby post-install hook ..."
+	"$install_dir/lib/truffle/post_install_hook.sh" || return $?
+}

--- a/share/ruby-install/truffleruby/functions.sh
+++ b/share/ruby-install/truffleruby/functions.sh
@@ -1,17 +1,7 @@
 #!/usr/bin/env bash
 
-# Check platform
-case $(uname) in
-	Linux) platform=linux ;;
-	Darwin) platform=macos ;;
-	*) fail "unknown platform $(uname)" ;;
-esac
-
-# Check architecture
-case $(uname -m) in
-	x86_64) arch=amd64 ;;
-	*) fail "unknown architecture $(uname -m)" ;;
-esac
+platform=$(platform) || return $?
+arch=$(architecture) || return $?
 
 ruby_dir_name="truffleruby-$ruby_version-$platform-$arch"
 ruby_archive="$ruby_dir_name.tar.gz"

--- a/share/ruby-install/util.sh
+++ b/share/ruby-install/util.sh
@@ -121,3 +121,28 @@ function extract()
 			;;
 	esac
 }
+
+#
+# Returns the executing platform.
+#
+function platform()
+{
+	local uname="$(uname)"
+	case "$uname" in
+		Linux) echo linux ;;
+		Darwin) echo macos ;;
+		*) fail "unknown platform $uname" ;;
+	esac
+}
+
+#
+# Returns the CPU architecture.
+#
+function architecture()
+{
+	local arch="$(uname -m)"
+	case "$arch" in
+		x86_64) echo amd64 ;;
+		*) fail "unknown architecture $arch" ;;
+	esac
+}

--- a/share/ruby-install/util.sh
+++ b/share/ruby-install/util.sh
@@ -131,7 +131,10 @@ function platform()
 	case "$uname" in
 		Linux) echo linux ;;
 		Darwin) echo macos ;;
-		*) fail "unknown platform $uname" ;;
+		*)
+			error "unknown platform $uname"
+			return 1
+			;;
 	esac
 }
 
@@ -143,6 +146,9 @@ function architecture()
 	local arch="$(uname -m)"
 	case "$arch" in
 		x86_64) echo amd64 ;;
-		*) fail "unknown architecture $arch" ;;
+		*)
+			error "unknown architecture $arch"
+			return 1
+			;;
 	esac
 }

--- a/test/ruby-install-tests/list_rubies_test.sh
+++ b/test/ruby-install-tests/list_rubies_test.sh
@@ -9,6 +9,7 @@ function test_list_rubies()
 	assertTrue "did not include ruby" '[[ "$output" == *ruby:* ]]'
 	assertTrue "did not include jruby" '[[ "$output" == *jruby:* ]]'
 	assertTrue "did not include rbx" '[[ "$output" == *rbx:* ]]'
+	assertTrue "did not include truffleruby" '[[ "$output" == *truffleruby:* ]]'
 	assertTrue "did not include mruby" '[[ "$output" == *mruby:* ]]'
 }
 

--- a/test/ruby-install-tests/variables_test.sh
+++ b/test/ruby-install-tests/variables_test.sh
@@ -30,8 +30,8 @@ function test_ruby_install_cache_dir()
 
 function test_rubies()
 {
-	for ruby in ruby jruby rbx mruby; do
-		assertTrue "did not contain ruby" \
+	for ruby in ruby jruby rbx truffleruby mruby; do
+		assertTrue "did not contain $ruby" \
 			   "[[ \" \${rubies[@]} \" == *\" $ruby \"* ]]"
 	done
 }


### PR DESCRIPTION
Hello,

Here is a PR to add [TruffleRuby](https://github.com/oracle/truffleruby) to ruby-install.
Corresponding PR for ruby-versions at https://github.com/postmodern/ruby-versions/pull/27.
I tried to keep the logic as simple as possible, and to update all relevant places mentioning other implementations.

I tested it locally and it seems to work well.

This is a fully open-source version of TruffleRuby, corresponding to a subset of the Community Edition of GraalVM (See http://www.graalvm.org/downloads/)
It includes the [`native` configuration](https://github.com/oracle/truffleruby#truffleruby-configurations) only, not the `JVM` configuration, so there is no JVM involved.

cc @havenwood