### PR TITLE
Ensure extract_ruby() extracts to the given directory

### DIFF
--- a/share/ruby-install/functions.sh
+++ b/share/ruby-install/functions.sh
@@ -61,7 +61,7 @@ function verify_ruby()
 function extract_ruby()
 {
 	log "Extracting $ruby_archive to $src_dir/$ruby_dir_name ..."
-	extract "$src_dir/$ruby_archive" "$src_dir" || return $?
+	extract "$src_dir/$ruby_archive" "$src_dir/$ruby_dir_name" || return $?
 }
 
 #

--- a/share/ruby-install/util.sh
+++ b/share/ruby-install/util.sh
@@ -105,19 +105,27 @@ function download()
 
 #
 # Extracts an archive.
+# The archive should contain a single directory.
 #
 function extract()
 {
 	local archive="$1"
-	local dest="${2:-${archive%/*}}"
+	local dest="$2"
+	local tmp="${dest}_tmp"
+
+	rm -rf "$tmp" "$dest" || return $?
+	mkdir "$tmp" || return $?
 
 	case "$archive" in
-		*.tgz|*.tar.gz) tar -xzf "$archive" -C "$dest" || return $? ;;
-		*.tbz|*.tbz2|*.tar.bz2)	tar -xjf "$archive" -C "$dest" || return $? ;;
-		*.zip) unzip "$archive" -d "$dest" || return $? ;;
+		*.tgz|*.tar.gz) tar -xzf "$archive" -C "$tmp" || return $? ;;
+		*.tbz|*.tbz2|*.tar.bz2)	tar -xjf "$archive" -C "$tmp" || return $? ;;
+		*.zip) unzip "$archive" -d "$tmp" || return $? ;;
 		*)
 			error "Unknown archive format: $archive"
 			return 1
 			;;
 	esac
+
+	mv "$tmp"/* "$dest" || return $?
+	rmdir "$tmp" || return $?
 }


### PR DESCRIPTION
* So the name of the directory in the archive can vary and ruby-install can keep working.
* If the archive contains multiple top-level files/directories, extract() will error instead of creating multiple entries in ~/src. This is achieved by `mv` already returning an error when more than 2 arguments are passed if the last argument is not an existing directory (`mv: target '/home/eregon/src/truffleruby-1.0.0-rc2-linux-amd64' is not a directory`).
* The existing implementation hoped the archive contains a directory of the right name, and if not later steps would fail.

Currently, TruffleRuby release archives need to contain a single known-in-advance directory, with a unique name per version. This requirement is mostly to fit what `ruby-install` expects.
So `truffleruby-1.0.0-rc2-linux-amd64.tar.gz` contains `truffleruby-1.0.0-rc2-linux-amd64` currently.

I would like to have the flexibility to change the directory name inside the archive for future releases.
For instance, the archive could contain a single `truffleruby-1.0.0-rc2` directory (without the platform) or maybe just `truffleruby`, etc.

Other Ruby managers already allow such flexibility, but ruby-install does not so far.
This PR fixes this while trying to keep things as simple as possible.

Also, it ensures that if the archive contained multiple top-level files or directories, it would error out and not extract multiple directories/files in ~/src which can get messy.

cc @postmodern @havenwood 