### PR TITLE
Transform ruby name to lowercase

### DIFF
--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -77,7 +77,7 @@ USAGE
 #
 function parse_ruby()
 {
-	local arg="$1"
+	local arg=$(echo "$1" | tr '[:upper:]' '[:lower:]')
 
 	case "$arg" in
 		*-*)


### PR DESCRIPTION
Hello,

Today, I wanted to use ruby-install by copying / pasting the new `Ruby 2.6.0-rc1` version from the blog. And your utility said `!!! Ruby Unknown: Ruby`

I think it's not a good idea to not allow capitalization. I send you this PR with the hope that you like it.

I wish you a Merry Christmas with your family