### PR TITLE
Fix the usage help to respect the correct usage of the --jobs option

### DIFF
--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -40,7 +40,7 @@ Options:
 	    --system		Alias for -i $system_dir
 	-s, --src-dir DIR	Directory to download source-code into
 	-c, --cleanup		Remove archive and unpacked source-code after installation
-	-j, --jobs JOBS		Number of jobs to run in parallel when compiling
+	-j, --jobs=JOBS		Number of jobs to run in parallel when compiling
 	-p, --patch FILE	Patch to apply to the Ruby source-code
 	-M, --mirror URL	Alternate mirror to download the Ruby archive from
 	-u, --url URL		Alternate URL to download the Ruby archive from


### PR DESCRIPTION
The `--jobs` options requires an `=` sign to work. Without the equal sign, the number of jobs is interpreted as the ruby version to install.

The problem is described in more details in #328 
