### PR TITLE
add hyphen to syntax of command line ruby argument for correct version install

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ Install the latest version of Ruby:
 
 Install a stable version of Ruby:
 
-    $ ruby-install ruby 2.3
+    $ ruby-install ruby-2.3
 
 Install a specific version of Ruby:
 
-    $ ruby-install ruby 2.2.4
+    $ ruby-install ruby-2.2.4
 
 Install a Ruby into a specific directory:
 
@@ -80,31 +80,31 @@ Install a Ruby into a specific `rubies` directory:
 
 Install a Ruby into `/usr/local`:
 
-    $ ruby-install --system ruby 2.4.0
+    $ ruby-install --system ruby-2.4.0
 
 Install a Ruby from an official site with directly download:
 
-    $ ruby-install -M https://ftp.ruby-lang.org/pub/ruby ruby 2.4.0
+    $ ruby-install -M https://ftp.ruby-lang.org/pub/ruby ruby-2.4.0
 
 Install a Ruby from a mirror:
 
-    $ ruby-install -M http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby ruby 2.0.0-p645
+    $ ruby-install -M http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby ruby-2.0.0-p645
 
 Install a Ruby with a specific patch:
 
-    $ ruby-install -p https://raw.github.com/gist/4136373/falcon-gc.diff ruby 1.9.3-p551
+    $ ruby-install -p https://raw.github.com/gist/4136373/falcon-gc.diff ruby-1.9.3-p551
 
 Install a Ruby with a specific C compiler:
 
-    $ ruby-install ruby 2.4.0 -- CC=gcc-4.9
+    $ ruby-install ruby-2.4.0 -- CC=gcc-4.9
 
 Install a Ruby with specific configuration:
 
-    $ ruby-install ruby 2.4.0 -- --enable-shared --enable-dtrace CFLAGS="-O3"
+    $ ruby-install ruby-2.4.0 -- --enable-shared --enable-dtrace CFLAGS="-O3"
 
 Install a Ruby without installing dependencies first:
 
-    $ ruby-install --no-install-deps ruby 2.4.0
+    $ ruby-install --no-install-deps ruby-2.4.0
 
 Uninstall a Ruby version:
 
@@ -114,11 +114,11 @@ Uninstall a Ruby version:
 
 Using ruby-install with [RVM]:
 
-    $ ruby-install --rubies-dir ~/.rvm/rubies ruby 2.4.0
+    $ ruby-install --rubies-dir ~/.rvm/rubies ruby-2.4.0
 
 Using ruby-install with [rbenv]:
 
-    $ ruby-install --install-dir ~/.rbenv/versions/2.4.0 ruby 2.4.0
+    $ ruby-install --install-dir ~/.rbenv/versions/2.4.0 ruby-2.4.0
 
 ruby-install can even be used with [Chef].
 
@@ -176,7 +176,7 @@ installed. OS X users can install GCC via [homebrew]:
 
 And run ruby-install again:
 
-    ruby-install ruby 2.4.0 -- CC=gcc-4.9
+    ruby-install ruby-2.4.0 -- CC=gcc-4.9
 
 ### Rubinius
 


### PR DESCRIPTION
Running the arguments ```ruby-install ruby x.y.z``` as per current README installs the latest stable version of ruby instead of version x.y.z as it is missing a hyphen between the ruby and the version.
Changed all instances in README of ```ruby x.y.z``` to ```ruby-x.y.z```.