### PR TITLE
Add missing grep and awk dependencies for pacman

### DIFF
--- a/share/ruby-install/ruby/dependencies.txt
+++ b/share/ruby-install/ruby/dependencies.txt
@@ -3,6 +3,6 @@ dnf: gcc automake bison zlib-devel libyaml-devel openssl-devel gdbm-devel readli
 yum: gcc automake bison zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel libffi-devel
 port: automake bison openssl readline libyaml gdbm libffi
 brew: automake bison openssl readline libyaml gdbm libffi
-pacman: gcc make bison zlib ncurses openssl readline libyaml gdbm libffi
+pacman: gcc make bison zlib ncurses openssl readline libyaml gdbm libffi grep awk
 zypper: gcc make automake zlib-devel libyaml-devel libopenssl-devel gdbm-devel readline-devel ncurses-devel libffi-devel
 pkg: openssl readline libyaml gdbm libffi


### PR DESCRIPTION
The default Arch Docker image doesn't have these installed.

Reproduction:

```dockerfile
FROM archlinux/base

RUN pacman -Syu --noconfirm sudo make && \
    curl -Lo ruby-install-master.tar.gz https://github.com/postmodern/ruby-install/archive/master.tar.gz && \
    tar -xzvf ruby-install-master.tar.gz && \
    cd ruby-install-master && \
    make install && \
    pacman -Syu --noconfirm grep awk && \
    yes | ruby-install ruby
```