### PR TITLE
[util.sh#fetch()] Change invalid comment

### DIFF
--- a/share/ruby-install/util.sh
+++ b/share/ruby-install/util.sh
@@ -63,7 +63,7 @@ function fail()
 
 #
 # Searches a file for a key and echos the value.
-# If the key cannot be found, the third argument will be echoed.
+# Nothing is returned if the key cannot be found.
 #
 function fetch()
 {


### PR DESCRIPTION
Returning a default value has been removed in: 5d53601

Changed it to represent the current functionality.  Can be tested from the project dir by running:

```console
$ export ruby_install_dir=$(pwd)/share/ruby-install
$ source share/ruby-install/util.sh
$ fetch ruby/dependencies foo
$ fetch ruby/dependencies $package_manager
automake bison openssl readline libyaml gdbm libffi
```