### PR TITLE
fix(uninstall): DO NOT ERASE /usr/local/share

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,6 @@ install:
 uninstall:
 	for file in $(INSTALL_FILES); do rm -f $(DESTDIR)$(PREFIX)/$$file; done
 	rm -rf $(DESTDIR)$(DOC_DIR)
-	rmdir $(DESTDIR)$(SHARE_DIR)
+	rm -rf $(DESTDIR)$(SHARE_DIR)/ruby-install
 
 .PHONY: build man download sign verify clean check test tag release rpm install uninstall all


### PR DESCRIPTION
bacause of b87e5955f770491ede60e41404badd91a6610ccc
make uninstall fail and produce error below:

```
for file in `find bin share -type f`; do rm -f /usr/local/$file; done
rm -rf /usr/local/share/doc/ruby-install-0.7.0
rmdir /usr/local/share
rmdir: '/usr/local/share': Directory not empty
make: *** [Makefile:78: uninstall] Error 1
```

We should just remove `/usr/local/share/ruby-install`, not `/usr/local/share`.