### PR TITLE
Use sudo -E to pass environment variables through to brew.

### DIFF
--- a/share/ruby-install/package_manager.sh
+++ b/share/ruby-install/package_manager.sh
@@ -25,7 +25,7 @@ function install_packages()
 			local brew_sudo=""
 
 			if [[ "$brew_owner" != "$(id -un)" ]]; then
-				brew_sudo="sudo -u $brew_owner"
+				brew_sudo="sudo -Eu $brew_owner"
 			fi
 
 			$brew_sudo brew install "$@" ||


### PR DESCRIPTION
`brew` uses environment variables to control many aspects of how it
operates. Using `sudo` with `-E` allows those variables to be used to
keep the build/setup consistent with the existing environment.