### PR TITLE
Update TruffleRuby dependencies

### DIFF
--- a/share/ruby-install/truffleruby/dependencies.txt
+++ b/share/ruby-install/truffleruby/dependencies.txt
@@ -1,8 +1,8 @@
-apt: zlib1g-dev libssl-dev clang llvm make
-dnf: zlib-devel openssl-devel clang llvm make
-yum: zlib-devel openssl-devel clang llvm make
-port: openssl llvm-4.0
-brew: openssl llvm@4
-pacman: zlib openssl clang llvm make
-zypper: zlib-devel libopenssl-devel llvm-clang llvm make
-pkg: openssl llvm-devel
+apt: zlib1g-dev libssl-dev make gcc libxml2
+dnf: zlib-devel openssl-devel make gcc libxml2
+yum: zlib-devel openssl-devel make gcc libxml2
+port: openssl
+brew: openssl
+pacman: zlib openssl make gcc libxml2
+zypper: zlib-devel libopenssl-devel make gcc libxml2
+pkg: openssl gmake gcc libxml2


### PR DESCRIPTION
* TruffleRuby 19.3+ uses an internal LLVM toolchain and no longer depends on LLVM.
* The full dependencies are listed at
  https://github.com/oracle/truffleruby/blob/master/README.md#dependencies
* Previous versions of TruffleRuby detect if LLVM is missing and print
  a nice error message, so it is not an issue to remove the dependency
  for older versions.

@postmodern @havenwood Could you merge this soon as it might prevent macOS Cataline users to install TruffleRuby? (https://github.com/oracle/truffleruby/issues/1820 for details)