### PR TITLE
Add support for downloading truffleruby-head

### DIFF
--- a/share/ruby-install/truffleruby/functions.sh
+++ b/share/ruby-install/truffleruby/functions.sh
@@ -3,10 +3,22 @@
 platform=$(platform) || return $?
 arch=$(architecture) || return $?
 
-ruby_dir_name="truffleruby-$ruby_version-$platform-$arch"
-ruby_archive="$ruby_dir_name.tar.gz"
-ruby_mirror="${ruby_mirror:-https://github.com/oracle/truffleruby/releases/download}"
-ruby_url="${ruby_url:-$ruby_mirror/vm-$ruby_version/$ruby_archive}"
+if [[ "$ruby_version" == "head" ]]; then
+	local head_platform
+	case "$platform" in
+		linux) head_platform="ubuntu-18.04" ;;
+		macos) head_platform="macos-latest" ;;
+	esac
+	ruby_dir_name="truffleruby-head"
+	ruby_archive="truffleruby-head-$head_platform.tar.gz"
+	ruby_mirror="${ruby_mirror:-https://github.com/ruby/truffleruby-dev-builder/releases/latest/download}"
+	ruby_url="${ruby_url:-$ruby_mirror/$ruby_archive}"
+else
+	ruby_dir_name="truffleruby-$ruby_version-$platform-$arch"
+	ruby_archive="$ruby_dir_name.tar.gz"
+	ruby_mirror="${ruby_mirror:-https://github.com/oracle/truffleruby/releases/download}"
+	ruby_url="${ruby_url:-$ruby_mirror/vm-$ruby_version/$ruby_archive}"
+fi
 
 #
 # Install TruffleRuby into $install_dir.


### PR DESCRIPTION
* Uses the latest nightly, which is automatically built.
* Similar to https://github.com/rbenv/ruby-build/pull/1405

Only the URL changes, the way to install remains exactly the same.

Corresponding one-line change in ruby-versions: https://github.com/postmodern/ruby-versions/pull/48

Ref: https://github.com/oracle/truffleruby/issues/1483
We want to make it easy for users to try the latest TruffleRuby nightly.

This PR allows:
```
$ ruby-install truffleruby head
>>> Installing truffleruby head into /home/eregon/.rubies/truffleruby-head ...
>>> Installing dependencies for truffleruby head ...
...
>>> Downloading https://github.com/ruby/truffleruby-dev-builder/releases/latest/download/truffleruby-head-ubuntu-18.04.tar.gz into /home/eregon/src ...
...
>>> Verifying truffleruby-head-ubuntu-18.04.tar.gz ...
*** No md5 checksum for /home/eregon/src/truffleruby-head-ubuntu-18.04.tar.gz
*** No sha1 checksum for /home/eregon/src/truffleruby-head-ubuntu-18.04.tar.gz
*** No sha256 checksum for /home/eregon/src/truffleruby-head-ubuntu-18.04.tar.gz
*** No sha512 checksum for /home/eregon/src/truffleruby-head-ubuntu-18.04.tar.gz
>>> Extracting truffleruby-head-ubuntu-18.04.tar.gz to /home/eregon/src/truffleruby-head ...
>>> Installing truffleruby head ...
>>> Running truffleruby post-install hook ...
...
>>> Successfully installed truffleruby head into /home/eregon/.rubies/truffleruby-head
```

cc @havenwood @postmodern @deepj