### PR TITLE
support modern apt with ruby-dev, llvm-dev, and clang

### DIFF
--- a/share/ruby-install/rbx/dependencies.txt
+++ b/share/ruby-install/rbx/dependencies.txt
@@ -1,4 +1,4 @@
-apt: gcc g++ automake flex bison ruby1.9.1-dev llvm-3.5-dev libedit-dev zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev
+apt: gcc g++ automake flex bison ruby-dev llvm-dev libedit-dev zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev clang
 dnf: gcc gcc-c++ automake flex bison ruby-devel rubygems llvm-static llvm-devel libedit-devel zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel
 yum: gcc gcc-c++ automake flex bison ruby-devel rubygems llvm-static llvm-devel libedit-devel zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel
 port: openssl readline libyaml gdbm


### PR DESCRIPTION
This addresses #279 

I did notice some errors and warnings in the output, however.  Nonetheless, I get a so-far successful rbx install.

```
rwh@debian:~/git/ruby-install$ uname -a
Linux debian 4.19.0-8-amd64 #1 SMP Debian 4.19.98-1 (2020-01-26) x86_64 GNU/Linux
```