### PR TITLE
Add support for installing GraalVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,6 @@ before_script:
   - __rvm_unload
   - export SHUNIT2="$(command -v shunit2 2>/dev/null)"
 
-script: make test
+script:
+  - make lint
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ clean:
 check:
 	shellcheck --exclude SC2034 share/$(NAME)/*.sh bin/*
 
+lint:
+	# Check dependencies are consistent for truffleruby and graalvm
+	diff share/ruby-install/graalvm/dependencies.txt share/ruby-install/truffleruby/dependencies.txt
+
 test:
 	./test/runner
 

--- a/share/ruby-install/graalvm/dependencies.txt
+++ b/share/ruby-install/graalvm/dependencies.txt
@@ -1,0 +1,8 @@
+apt: zlib1g-dev libssl-dev make gcc libxml2
+dnf: zlib-devel openssl-devel make gcc libxml2
+yum: zlib-devel openssl-devel make gcc libxml2
+port: openssl
+brew: openssl
+pacman: zlib openssl make gcc libxml2
+zypper: zlib-devel libopenssl-devel make gcc libxml2
+pkg: openssl gmake gcc libxml2

--- a/share/ruby-install/graalvm/functions.sh
+++ b/share/ruby-install/graalvm/functions.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+platform=$(platform) || return $?
+graalvm_platform="${platform/macos/darwin}"
+arch=$(architecture) || return $?
+
+ruby_dir_name="graalvm-ce-java8-$ruby_version"
+ruby_archive="graalvm-ce-java8-$graalvm_platform-$arch-$ruby_version.tar.gz"
+ruby_mirror="${ruby_mirror:-https://github.com/graalvm/graalvm-ce-builds/releases/download}"
+ruby_url="${ruby_url:-$ruby_mirror/vm-$ruby_version/$ruby_archive}"
+
+#
+# Install GraalVM into $install_dir.
+#
+function install_ruby()
+{
+	log "Installing GraalVM $ruby_version ..."
+	cp -R "$src_dir/$ruby_dir_name" "$install_dir" || return $?
+}
+
+#
+# Post-install tasks.
+#
+function post_install()
+{
+	log "Installing the Ruby component ..."
+	"$install_dir/bin/gu" install ruby || return $?
+
+	log "Running truffleruby post-install hook ..."
+	local ruby_home
+	ruby_home=$("$install_dir/bin/ruby" -e 'print RbConfig::CONFIG["prefix"]')
+	"$ruby_home/lib/truffle/post_install_hook.sh" || return $?
+}

--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -6,7 +6,7 @@ ruby_install_version="0.7.0"
 ruby_install_dir="${BASH_SOURCE[0]%/*}"
 ruby_install_cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/ruby-install"
 
-rubies=(ruby jruby rbx truffleruby mruby)
+rubies=(ruby jruby rbx truffleruby graalvm mruby)
 patches=()
 configure_opts=()
 make_opts=()


### PR DESCRIPTION
* Supports using other GraalVM languages such as JavaScript, Python, R and Java.
* Supports running TruffleRuby on JVM and not only Native (see https://github.com/oracle/truffleruby#truffleruby-runtime-configurations).