### PR TITLE
Remove the installation directory if it already exists and ends with the ruby name

### DIFF
--- a/bin/ruby-install
+++ b/bin/ruby-install
@@ -21,6 +21,11 @@ if [[ $no_reinstall -eq 1 ]] && [[ -x "$install_dir/bin/ruby" ]]; then
 	exit
 fi
 
+if [[ -d "$install_dir" ]] && [[ $(basename "$install_dir") == "$ruby-$ruby_version" ]]; then
+	log "Removing previously-installed $install_dir"
+	rm -rf "$install_dir"
+fi
+
 log "Installing $ruby $ruby_version into $install_dir ..."
 
 pre_install || fail "Pre-install tasks failed!"


### PR DESCRIPTION
* Otherwise the installation directory might contain old files and
  give unpredictable results.
* Only removes if the $install_dir is "$ruby_engine-$ruby_version", which
  is safe to remove. If the $install_dir is e.g. /usr/local then it will
  not be removed (as it might contain other things than that Ruby installation).

(from https://github.com/postmodern/ruby-install/pull/377#issuecomment-701342011)