### PR TITLE
Do not use sudo for brew if not necessary

### DIFF
--- a/share/ruby-install/package_manager.sh
+++ b/share/ruby-install/package_manager.sh
@@ -22,8 +22,11 @@ function install_packages()
 		pkg)	$sudo pkg install -y "$@" || return $?     ;;
 		brew)
 			local brew_owner="$(/usr/bin/stat -f %Su "$(command -v brew)")"
-			sudo -u "$brew_owner" brew install "$@" ||
-			sudo -u "$brew_owner" brew upgrade "$@" || return $?
+			if [[ $brew_owner != $(id -un) ]]; then
+				local brew_sudo="sudo -u $brew_owner"
+			fi
+			${brew_sudo:-} brew install "$@" ||
+			${brew_sudo:-} brew upgrade "$@" || return $?
 			;;
 		pacman)
 			local missing_pkgs=($(pacman -T "$@"))


### PR DESCRIPTION
Normally, brew installations do not require sudo. There might be
certain cases where it does, so this commit preserves the old behaviour
where ownership of the brew script isn't the same as the user executing
ruby-install. Otherwise, sudo is omitted.

This also solves #128 for situations where the issue was caused by sudo
not preserving the user's environment (proxy failures could also be
caused by a host of other reasons, but it's the main reason why the issue was created originally).