### PR TITLE
Update the TruffleRuby + GraalVM CE distribution to use Java 11.

### DIFF
--- a/share/ruby-install/truffleruby-graalvm/functions.sh
+++ b/share/ruby-install/truffleruby-graalvm/functions.sh
@@ -11,8 +11,8 @@ case "$os_arch" in
 	*)	fail "Unsupported architecture $os_arch" ;;
 esac
 
-ruby_dir_name="graalvm-ce-java8-$ruby_version"
-ruby_archive="${ruby_archive:-graalvm-ce-java8-$graalvm_platform-$graalvm_arch-$ruby_version.tar.gz}"
+ruby_dir_name="graalvm-ce-java11-$ruby_version"
+ruby_archive="${ruby_archive:-graalvm-ce-java11-$graalvm_platform-$graalvm_arch-$ruby_version.tar.gz}"
 ruby_mirror="${ruby_mirror:-https://github.com/graalvm/graalvm-ce-builds/releases/download}"
 ruby_url="${ruby_url:-$ruby_mirror/vm-$ruby_version/$ruby_archive}"
 


### PR DESCRIPTION
GraalVM Community Edition (CE), which bundles its own version of Java, ships with various Java versions as its base. Java 11 is the latest long-term support and the recommended version to use. Incidentally, there are no Java 8-based GraalVM CE builds for macOS, so moving to the Java 11 base allows installation on macOS as well.