### PR TITLE
Remove ';;' from `if` body to avoid syntax error

### DIFF
--- a/share/ruby-install/truffleruby/functions.sh
+++ b/share/ruby-install/truffleruby/functions.sh
@@ -23,7 +23,7 @@ function install_ruby()
 {
 	if [[ "$install_dir" == '/usr/local' ]]; then
 		error "Unsupported see https://github.com/oracle/truffleruby/issues/1389"
-		return 1 ;;
+		return 1
 	fi
 
 	log "Installing truffleruby $ruby_version ..."


### PR DESCRIPTION
This resulted in

```
/usr/local/bin/../share/ruby-install/truffleruby/functions.sh: line 26: syntax error near unexpected token `;;'
/usr/local/bin/../share/ruby-install/truffleruby/functions.sh: line 26: `               return 1 ;;'
```