### PR TITLE
Force homebrew to use OpenSSL 1.1

### DIFF
--- a/share/ruby-install/rbx/dependencies.txt
+++ b/share/ruby-install/rbx/dependencies.txt
@@ -2,7 +2,7 @@ apt: gcc g++ automake flex bison ruby-dev llvm-dev libedit-dev zlib1g-dev libyam
 dnf: gcc gcc-c++ automake flex bison ruby-devel rubygems llvm-static llvm-devel libedit-devel zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel
 yum: bzip2 gcc gcc-c++ automake flex bison ruby-devel rubygems llvm-static llvm-devel libedit-devel zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel
 port: openssl readline libyaml gdbm
-brew: openssl readline libyaml gdbm
+brew: openssl@1.1 readline libyaml gdbm
 pacman: gcc automake flex bison ruby llvm libedit zlib libyaml openssl gdbm readline ncurses
 zypper: gcc gcc-c++ make automake flex bison ruby2.2-devel ruby2.2-rubygem-bundler llvm-devel zlib-devel libyaml-devel libopenssl-devel gdbm-devel readline-devel ncurses-devel
 pkg: gmake flex bison ruby devel/ruby-gems llvm-devel openssl readline libyaml gdbm

--- a/share/ruby-install/rbx/functions.sh
+++ b/share/ruby-install/rbx/functions.sh
@@ -31,7 +31,7 @@ function configure_ruby()
 	log "Configuring rubinius $ruby_version ..."
 	case "$package_manager" in
 		brew)
-			opt_dir="$(brew --prefix openssl):$(brew --prefix readline):$(brew --prefix libyaml):$(brew --prefix gdbm)"
+			opt_dir="$(brew --prefix openssl@1.1):$(brew --prefix readline):$(brew --prefix libyaml):$(brew --prefix gdbm)"
 			;;
 		port)
 			opt_dir="/opt/local"

--- a/share/ruby-install/ruby/dependencies.txt
+++ b/share/ruby-install/ruby/dependencies.txt
@@ -2,7 +2,7 @@ apt: xz-utils build-essential bison zlib1g-dev libyaml-dev libssl-dev libgdbm-de
 dnf: xz gcc automake bison zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel libffi-devel
 yum: xz gcc automake bison zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel libffi-devel
 port: automake bison openssl readline libyaml gdbm libffi
-brew: automake bison openssl readline libyaml gdbm libffi
+brew: automake bison openssl@1.1 readline libyaml gdbm libffi
 pacman: xz gcc make bison zlib ncurses openssl readline libyaml gdbm libffi
 zypper: xz gcc make automake zlib-devel libyaml-devel libopenssl-devel gdbm-devel readline-devel ncurses-devel libffi-devel
 pkg: openssl readline libyaml gdbm libffi

--- a/share/ruby-install/ruby/functions.sh
+++ b/share/ruby-install/ruby/functions.sh
@@ -28,7 +28,7 @@ function configure_ruby()
 	log "Configuring ruby $ruby_version ..."
 	case "$package_manager" in
 		brew)
-			opt_dir="$(brew --prefix openssl):$(brew --prefix readline):$(brew --prefix libyaml):$(brew --prefix gdbm)"
+			opt_dir="$(brew --prefix openssl@1.1):$(brew --prefix readline):$(brew --prefix libyaml):$(brew --prefix gdbm)"
 			;;
 		port)
 			opt_dir="/opt/local"

--- a/share/ruby-install/truffleruby-graalvm/dependencies.txt
+++ b/share/ruby-install/truffleruby-graalvm/dependencies.txt
@@ -2,7 +2,7 @@ apt: zlib1g-dev libssl-dev make gcc libxml2
 dnf: zlib-devel openssl-devel make gcc libxml2
 yum: zlib-devel openssl-devel make gcc libxml2
 port: openssl
-brew: openssl
+brew: openssl@1.1
 pacman: zlib openssl make gcc libxml2
 zypper: zlib-devel libopenssl-devel make gcc libxml2
 pkg: openssl gmake gcc libxml2

--- a/share/ruby-install/truffleruby/dependencies.txt
+++ b/share/ruby-install/truffleruby/dependencies.txt
@@ -2,7 +2,7 @@ apt: zlib1g-dev libssl-dev make gcc libxml2
 dnf: zlib-devel openssl-devel make gcc libxml2
 yum: zlib-devel openssl-devel make gcc libxml2
 port: openssl
-brew: openssl
+brew: openssl@1.1
 pacman: zlib openssl make gcc libxml2
 zypper: zlib-devel libopenssl-devel make gcc libxml2
 pkg: openssl gmake gcc libxml2


### PR DESCRIPTION
OpenSSL 3.0 is released, and Homebrew uses it by default now, but Ruby doesn't support it yet.
See the issue at https://github.com/postmodern/ruby-install/issues/409