### PR TITLE
List installed Rubies

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ List the latest versions:
 
     $ ruby-install --latest
 
+List installed Rubies:
+
+    $ ruby-install --installed
+
 Install the current stable version of Ruby:
 
     $ ruby-install ruby

--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -59,6 +59,7 @@ Options:
 	--no-install-deps	Do not install build dependencies before installing Ruby
 	--no-reinstall  	Skip installation if another Ruby is detected in same location
 	-L, --latest		Downloads the latest ruby versions and checksums
+	-I, --installed		List installed ruby versions
 	-V, --version		Prints the version
 	-h, --help		Prints this message
 
@@ -193,6 +194,10 @@ function parse_options()
 				force_update=1
 				shift
 				;;
+      -I|--installed)
+        list_installed_rubies
+        return 1
+        ;;
 			-V|--version)
 				echo "ruby-install: $ruby_install_version"
 				exit
@@ -227,6 +232,14 @@ function parse_options()
 			return 1
 			;;
 	esac
+}
+
+#
+# List installed Rubies
+#
+function list_installed_rubies()
+{
+  ls -1 ${install_dir:-$rubies_dir}
 }
 
 #

--- a/test/ruby-install-tests/list_installed_rubies_test.sh
+++ b/test/ruby-install-tests/list_installed_rubies_test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+. ./test/helper.sh
+
+function test_list_installed_rubies()
+{
+	mkdir -p "$HOME/.rubies/ruby-2.7.5"
+	mkdir -p "$HOME/.rubies/ruby-3.1.0"
+
+	local output="$(list_installed_rubies)"
+
+	assertTrue "did include ruby-2.7.5" '[[ "$output" == *ruby-2.7.5* ]]'
+	assertTrue "did include ruby-3.1.0" '[[ "$output" == *ruby-3.1.0* ]]'
+}
+
+SHUNIT_PARENT=$0 . $SHUNIT2


### PR DESCRIPTION
This small addition adds `-I` or `--installed` to list installed Rubies. This is very useful for folks using ruby-install only (without chruby).

Thanks for considering to merge!