### PR TITLE
Update README to reflect new ruby-install port

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,9 @@ ruby-install is available on [Fedora Copr](https://copr.fedorainfracloud.org/cop
 
 ### FreeBSD
 
-There is a [FreeBSD port] of ruby-install which can be copied into the local
-ports tree.
+ruby-install is included in the official [FreeBSD ports collection]:
+
+    cd /usr/ports/devel/ruby-install/ && make install clean
 
 ## Known Issues
 
@@ -218,4 +219,4 @@ of [rbenv]
 
 [homebrew]: http://brew.sh/
 [AUR]: https://aur.archlinux.org/packages/ruby-install/
-[FreeBSD port]: https://github.com/steakknife/ruby-install-freebsd#readme
+[FreeBSD ports collection]: https://www.freshports.org/devel/ruby-install/


### PR DESCRIPTION
Hello!

I noticed the FreeBSD port linked in the README seemed to be stuck at version 0.6.0 and [had issues building on newer FreeBSDs](https://github.com/steakknife/ruby-install-freebsd/issues/6), so I took the liberty of putting together an updated port and submitting it for inclusion in the official port collection.

I'm happy to share [the port was accepted](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=264168), so here's a corresponding change to ruby-install's README to point folks to the now-official port. Thanks for chruby and ruby-install!