### PR TITLE
Use xzcat for tar implementations that don't do -J

### DIFF
--- a/share/ruby-install/util.sh
+++ b/share/ruby-install/util.sh
@@ -53,7 +53,7 @@ function extract()
 	case "$archive" in
 		*.tgz|*.tar.gz) tar -xzf "$archive" -C "$dest" || return $? ;;
 		*.tbz|*.tbz2|*.tar.bz2)	tar -xjf "$archive" -C "$dest" || return $? ;;
-		*.txz|*.tar.xz)	tar -xJf "$archive" -C "$dest" || return $? ;;
+		*.txz|*.tar.xz)	xzcat "$archive" | tar -xf - -C "$dest" || return $? ;;
 		*.zip) unzip "$archive" -d "$dest" || return $? ;;
 		*)
 			error "Unknown archive format: $archive"


### PR DESCRIPTION
OpenBSD as of 7.1  doesn't do `tar -xJf`.

This pull request uses `xzcat "$archive" | tar -xf - -C "$dest"` for `*.txz` and `*.tar.xz`.

`xzcat` seems available on Ubuntu/Debian and OSX. I haven't looked at other platforms.

Thanks a lot for ruby-install !
