### PR TITLE
Add support for AArch64 builds of TruffleRuby.

### DIFF
--- a/share/ruby-install/truffleruby-graalvm/functions.sh
+++ b/share/ruby-install/truffleruby-graalvm/functions.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 
 case "$os_platform" in
-	Linux)	graalvm_platform="linux" ;;
-	Darwin)	graalvm_platform="darwin" ;;
-	*)	fail "Unsupported platform $os_platform" ;;
+	Linux)   graalvm_platform="linux" ;;
+	Darwin)  graalvm_platform="darwin" ;;
+	*)       fail "Unsupported platform $os_platform" ;;
 esac
 
 case "$os_arch" in
-	x86_64)	graalvm_arch="amd64" ;;
-	*)	fail "Unsupported architecture $os_arch" ;;
+	x86_64)  graalvm_arch="amd64" ;;
+	aarch64) graalvm_arch="aarch64" ;;
+	arm64)   graalvm_arch="aarch64" ;;
+	*)       fail "Unsupported platform $os_arch" ;;
 esac
 
 ruby_dir_name="graalvm-ce-java11-$ruby_version"

--- a/share/ruby-install/truffleruby/functions.sh
+++ b/share/ruby-install/truffleruby/functions.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 
 case "$os_platform" in
-	Linux)	truffleruby_platform="linux" ;;
-	Darwin)	truffleruby_platform="macos" ;;
-	*)	fail "Unsupported platform $os_platform" ;;
+	Linux)   truffleruby_platform="linux" ;;
+	Darwin)  truffleruby_platform="macos" ;;
+	*)       fail "Unsupported platform $os_platform" ;;
 esac
 
 case "$os_arch" in
-	x86_64)	truffleruby_arch="amd64" ;;
-	*)	fail "Unsupported platform $os_arch" ;;
+	x86_64)  truffleruby_arch="amd64" ;;
+	aarch64) truffleruby_arch="aarch64" ;;
+	arm64)   truffleruby_arch="aarch64" ;;
+	*)       fail "Unsupported platform $os_arch" ;;
 esac
 
 ruby_dir_name="truffleruby-$ruby_version-$truffleruby_platform-$truffleruby_arch"


### PR DESCRIPTION
TruffleRuby 22.2.0 is the first release to support the new ARM-based Apple machines. AArch64 on Linux has also been present for a while. This PR allows TruffleRuby and the TruffleRuby+GraalVM builds to install on non-AMD64 platforms.