### PR TITLE
Add TruffleRuby and TruffleRuby+GraalVM 23.0.0

### DIFF
--- a/share/ruby-install/truffleruby-graalvm/dependencies.txt
+++ b/share/ruby-install/truffleruby-graalvm/dependencies.txt
@@ -1,9 +1,9 @@
-apt: zlib1g-dev libssl-dev make gcc libxml2
-dnf: zlib-devel openssl-devel make gcc libxml2
-yum: zlib-devel openssl-devel make gcc libxml2
-port: openssl
-brew: openssl@1.1
-pacman: zlib openssl make gcc libxml2
-zypper: zlib-devel libopenssl-devel make gcc libxml2
-pkg: openssl gmake gcc libxml2
-xbps: base-devel openssl-devel zlib-devel libxml2
+apt: zlib1g-dev libssl-dev make gcc libxml2 libyaml-dev
+dnf: zlib-devel openssl-devel make gcc libxml2 libyaml-devel
+yum: zlib-devel openssl-devel make gcc libxml2 libyaml-devel
+port: openssl libyaml
+brew: openssl@1.1 libyaml
+pacman: zlib openssl make gcc libxml2 libyaml
+zypper: zlib-devel libopenssl-devel make gcc libxml2 libyaml-devel
+pkg: openssl gmake gcc libxml2 libyaml
+xbps: base-devel openssl-devel zlib-devel libxml2 libyaml-devel

--- a/share/ruby-install/truffleruby-graalvm/functions.sh
+++ b/share/ruby-install/truffleruby-graalvm/functions.sh
@@ -13,10 +13,19 @@ case "$os_arch" in
 	*)       fail "Unsupported platform $os_arch" ;;
 esac
 
-ruby_dir_name="graalvm-ce-java11-$ruby_version"
-ruby_archive="${ruby_archive:-graalvm-ce-java11-$graalvm_platform-$graalvm_arch-$ruby_version.tar.gz}"
-ruby_mirror="${ruby_mirror:-https://github.com/graalvm/graalvm-ce-builds/releases/download}"
-ruby_url="${ruby_url:-$ruby_mirror/vm-$ruby_version/$ruby_archive}"
+if [ "$ruby_version" = "23.0.0" ]; then
+	log "TruffleRuby-GraalVM 23.0 and later installed by ruby-install use the faster Oracle GraalVM distribution"
+	log "Oracle GraalVM uses the GFTC license, which is free for development and production use, see https://medium.com/graalvm/161527df3d76"
+	ruby_dir_name="graalvm-jdk-17.0.7+8.1"
+	ruby_archive="${ruby_archive:-graalvm-jdk-17.0.7_${graalvm_platform/darwin/macos}-${graalvm_arch/amd64/x64}_bin.tar.gz}"
+	ruby_mirror="${ruby_mirror:-https://download.oracle.com/graalvm/17/archive}"
+	ruby_url="${ruby_url:-$ruby_mirror/$ruby_archive}"
+else
+	ruby_dir_name="graalvm-ce-java11-$ruby_version"
+	ruby_archive="${ruby_archive:-graalvm-ce-java11-$graalvm_platform-$graalvm_arch-$ruby_version.tar.gz}"
+	ruby_mirror="${ruby_mirror:-https://github.com/graalvm/graalvm-ce-builds/releases/download}"
+	ruby_url="${ruby_url:-$ruby_mirror/vm-$ruby_version/$ruby_archive}"
+fi
 
 #
 # Install GraalVM into $install_dir.

--- a/share/ruby-install/truffleruby/dependencies.txt
+++ b/share/ruby-install/truffleruby/dependencies.txt
@@ -1,9 +1,9 @@
-apt: zlib1g-dev libssl-dev make gcc libxml2
-dnf: zlib-devel openssl-devel make gcc libxml2
-yum: zlib-devel openssl-devel make gcc libxml2
-port: openssl
-brew: openssl@1.1
-pacman: zlib openssl make gcc libxml2
-zypper: zlib-devel libopenssl-devel make gcc libxml2
-pkg: openssl gmake gcc libxml2
-xbps: base-devel openssl-devel zlib-devel libxml2
+apt: zlib1g-dev libssl-dev make gcc libxml2 libyaml-dev
+dnf: zlib-devel openssl-devel make gcc libxml2 libyaml-devel
+yum: zlib-devel openssl-devel make gcc libxml2 libyaml-devel
+port: openssl libyaml
+brew: openssl@1.1 libyaml
+pacman: zlib openssl make gcc libxml2 libyaml
+zypper: zlib-devel libopenssl-devel make gcc libxml2 libyaml-devel
+pkg: openssl gmake gcc libxml2 libyaml
+xbps: base-devel openssl-devel zlib-devel libxml2 libyaml-devel

--- a/share/ruby-install/truffleruby/functions.sh
+++ b/share/ruby-install/truffleruby/functions.sh
@@ -15,8 +15,24 @@ esac
 
 ruby_dir_name="truffleruby-$ruby_version-$truffleruby_platform-$truffleruby_arch"
 ruby_archive="${ruby_archive:-$ruby_dir_name.tar.gz}"
-ruby_mirror="${ruby_mirror:-https://github.com/oracle/truffleruby/releases/download}"
-ruby_url="${ruby_url:-$ruby_mirror/vm-$ruby_version/$ruby_archive}"
+
+if [ "$ruby_version" = "23.0.0" ]; then
+	log "TruffleRuby 23.0 and later installed by ruby-install use the faster Oracle GraalVM distribution"
+	log "Oracle GraalVM uses the GFTC license, which is free for development and production use, see https://medium.com/graalvm/161527df3d76"
+	ruby_mirror="${ruby_mirror:-https://gds.oracle.com/api/20220101/artifacts}"
+	truffleruby_artifact_id=""
+	case "$truffleruby_platform-$truffleruby_arch" in
+		linux-amd64)    truffleruby_artifact_id="FD4AB182EA4CEDFDE0531518000AF13E" ;;
+		linux-aarch64)  truffleruby_artifact_id="FD40BA2367C226B6E0531518000AE71A" ;;
+		darwin-amd64)   truffleruby_artifact_id="FD4AB182EA51EDFDE0531518000AF13E" ;;
+		darwin-aarch64) truffleruby_artifact_id="FD40BBF6750C366CE0531518000ABEAF" ;;
+		*)              fail "Unsupported platform $truffleruby_platform-$truffleruby_arch" ;;
+	esac
+	ruby_url="${ruby_url:-$ruby_mirror/$truffleruby_artifact_id/content}"
+else
+	ruby_mirror="${ruby_mirror:-https://github.com/oracle/truffleruby/releases/download}"
+	ruby_url="${ruby_url:-$ruby_mirror/vm-$ruby_version/$ruby_archive}"
+fi
 
 #
 # Install TruffleRuby into $install_dir.


### PR DESCRIPTION
* Use the new Oracle GraalVM distribution which uses the GFTC license as it is significantly faster than GraalVM CE and is free for development and production use.
* See https://medium.com/graalvm/whats-new-in-graalvm-languages-161527df3d76

ruby-versions PR: https://github.com/postmodern/ruby-versions/pull/70