### PR TITLE
Fix macos handling for truffleruby artifacts

### DIFF
--- a/share/ruby-install/truffleruby/functions.sh
+++ b/share/ruby-install/truffleruby/functions.sh
@@ -24,8 +24,8 @@ if [ "$ruby_version" = "23.0.0" ]; then
 	case "$truffleruby_platform-$truffleruby_arch" in
 		linux-amd64)    truffleruby_artifact_id="FD4AB182EA4CEDFDE0531518000AF13E" ;;
 		linux-aarch64)  truffleruby_artifact_id="FD40BA2367C226B6E0531518000AE71A" ;;
-		darwin-amd64)   truffleruby_artifact_id="FD4AB182EA51EDFDE0531518000AF13E" ;;
-		darwin-aarch64) truffleruby_artifact_id="FD40BBF6750C366CE0531518000ABEAF" ;;
+		macos-amd64)   truffleruby_artifact_id="FD4AB182EA51EDFDE0531518000AF13E" ;;
+		macos-aarch64) truffleruby_artifact_id="FD40BBF6750C366CE0531518000ABEAF" ;;
 		*)              fail "Unsupported platform $truffleruby_platform-$truffleruby_arch" ;;
 	esac
 	ruby_url="${ruby_url:-$ruby_mirror/$truffleruby_artifact_id/content}"


### PR DESCRIPTION
We change darwin to macos at the top of this file.

I confirmed that on my mac i can install
- truffleruby-23.0.0
- truffleruby-22.3.0
- truffleruby-graalvm-23.0.0
- truffleruby-graalvm-22.3.0 