### PR TITLE
Use apt-get instead of apt

### DIFF
--- a/share/ruby-install/package_manager.sh
+++ b/share/ruby-install/package_manager.sh
@@ -17,7 +17,7 @@ function install_packages()
 {
 	case "$package_manager" in
 		apt)
-			run $sudo apt install -y "$@" || return $?
+			run $sudo apt-get install -y "$@" || return $?
 			;;
 		dnf|yum)
 			run $sudo "$package_manager" install -y "$@" || return $?

--- a/share/ruby-install/system.sh
+++ b/share/ruby-install/system.sh
@@ -38,7 +38,7 @@ function detect_package_manager()
 					package_manager="yum"
 				fi
 			elif [[ -f /etc/debian_version ]]; then
-				if command -v apt >/dev/null; then
+				if command -v apt-get >/dev/null; then
 					package_manager="apt"
 				fi
 			elif [[ -f /etc/SuSE-release ]]; then

--- a/test/system-tests/detect_package_manager_test.sh
+++ b/test/system-tests/detect_package_manager_test.sh
@@ -25,7 +25,7 @@ function test_detect_package_manager_on_redhat_based_systems_with_yum()
 
 function test_detect_package_manager_on_debian_based_systems_with_apt()
 {
-	[[ -f /etc/debian_version ]] && command -v apt >/dev/null || \
+	[[ -f /etc/debian_version ]] && command -v apt-get >/dev/null || \
 		return 0
 
 	detect_package_manager


### PR DESCRIPTION
When running non-interactively, this message appears in the logs:

    >>> Installing dependencies for ruby 3.2.1 ...
    WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

This isn't a huge deal, but apt doesn't appear to respect some options in /etc/apt/apt.conf.d/ when ran non-interactively. These options are respected when running apt-get. This is at least true for DPkg::Lock::Timeout, but may apply to other options as well.