### PR TITLE
warn user that installation will fail if she doesn't have necessary write permissions

### DIFF
--- a/share/ruby-install/functions.sh
+++ b/share/ruby-install/functions.sh
@@ -7,8 +7,22 @@ source "$ruby_install_dir/checksums.sh"
 #
 function pre_install()
 {
+
+	local status
+	local exisiting_part_dir="${install_dir%/*}"
+
 	mkdir -p "$src_dir" || return $?
-	mkdir -p "${install_dir%/*}" || return $?
+
+	while [ ! -d "$exisiting_part_dir" ]; do
+		exisiting_part_dir="${exisiting_part_dir%/*}"
+	done
+
+	if [ ! -w "$exisiting_part_dir" ]; then
+		fail "Installation directory is not writable by the user : ${exisiting_part_dir}"
+		status=$?
+	fi
+
+	mkdir -p "${install_dir%/*}" || return $status
 }
 
 #

--- a/test/cli-tests/warn_if_no_write_permissions_test.sh
+++ b/test/cli-tests/warn_if_no_write_permissions_test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+. ./test/helper.sh
+
+test_install_dir="$test_fixtures_dir/no_write_permissions_test"
+
+function setUp()
+{
+	mkdir -p "$test_install_dir/bin"
+	chmod -w "$test_install_dir/bin"
+}
+
+function test_no_write_permissions()
+{
+	local output status
+	output="$(ruby-install --install-dir "$test_install_dir/bin/rubies" ruby 2>&1)"
+	status=$?
+
+	assertEquals "did not return 0" 255 $status
+	assertTrue "did not print a message to STDOUT" \
+		'[[ "$output" == *"Installation directory is not writable by the user"* ]]'
+}
+
+function tearDown()
+{
+	rm -rf "$test_install_dir"
+}
+
+SHUNIT_PARENT=$0 . $SHUNIT2


### PR DESCRIPTION
added the guard logic against absent write permissions in `bin/ruby-install`  