### PR TITLE
Prefer --with-openssl-dir

### DIFF
--- a/share/ruby-install/ruby/functions.sh
+++ b/share/ruby-install/ruby/functions.sh
@@ -24,11 +24,13 @@ function configure_ruby()
 	fi
 
 	local opt_dir
+	local openssl_dir
 
 	log "Configuring ruby $ruby_version ..."
 	case "$package_manager" in
 		brew)
-			opt_dir="$(brew --prefix openssl@1.1):$(brew --prefix readline):$(brew --prefix libyaml):$(brew --prefix gdbm)"
+			opt_dir="$(brew --prefix readline):$(brew --prefix libyaml):$(brew --prefix gdbm)"
+			openssl_dir="$(brew --prefix openssl@1.1)"
 			;;
 		port)
 			opt_dir="/opt/local"
@@ -37,6 +39,7 @@ function configure_ruby()
 
 	run ./configure --prefix="$install_dir" \
 			"${opt_dir:+--with-opt-dir="$opt_dir"}" \
+			"${openssl_dir:+--with-openssl-dir="$openssl_dir"}" \
 			"${configure_opts[@]}" || return $?
 }
 


### PR DESCRIPTION
Fix https://github.com/postmodern/ruby-install/issues/458

When your homebrew has both `openssl@1.1` and `openssl@3` and you pass `--with-opt-dir=/opt/homebrew/opt/openssl@1.1` to `configure`, the build somehow mixes up both versions and fails.

It looks like `--with-openssl-dir` is the only correct way to specify an OpenSSL directory https://github.com/postmodern/ruby-install/issues/458#issuecomment-1667744262, so this PR uses it for Ruby 3.1.1 and newer (ref: https://github.com/postmodern/ruby-install/issues/458#issuecomment-1667746749). Older versions use the same option for backward compatibility, which would hopefully work if you don't have `openssl@3` locally.