### PR TITLE
Install xz as regular dependency

### DIFF
--- a/homebrew/ruby-install.rb
+++ b/homebrew/ruby-install.rb
@@ -6,8 +6,6 @@ class RubyInstall < Formula
   license "MIT"
   head "https://github.com/postmodern/ruby-install.git", branch: "master"
 
-  depends_on 'xz'
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "d19d4a89f08d447d522387e362b5e4627de5438e06396e2035fe735dc192d7de"
     sha256 cellar: :any_skip_relocation, big_sur:       "cd1ffd6780ab70d0701e812784ed7a7bb2276c6fc8f3303570fbf200a4f2ccde"

--- a/share/ruby-install/ruby/dependencies.txt
+++ b/share/ruby-install/ruby/dependencies.txt
@@ -1,8 +1,8 @@
 apt: xz-utils build-essential bison zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev
 dnf: xz gcc automake bison zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel libffi-devel
 yum: xz gcc automake bison zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel libffi-devel
-port: automake bison readline libyaml gdbm libffi
-brew: automake bison readline libyaml gdbm libffi
+port: xz automake bison readline libyaml gdbm libffi
+brew: xz automake bison readline libyaml gdbm libffi
 pacman: xz gcc make bison zlib ncurses openssl readline libyaml gdbm libffi
 zypper: xz gcc make automake zlib-devel libyaml-devel libopenssl-devel gdbm-devel readline-devel ncurses-devel libffi-devel
 pkg: openssl readline libyaml gdbm libffi


### PR DESCRIPTION
I found a corner case when [previous](https://github.com/postmodern/ruby-install/issues/429) `xz` install on macOS implementation doesn't work and propose a solution.

The previous implementation covered cases when we installed `ruby-install` on macOS via `brew` and that worked well. 
But in our case, we install (implicitly) `ruby-install` using [mise](https://mise.jdx.dev/lang/ruby.html), that don't use brew to install it under the hood, and as a consequence we miss brew formula dependencies installation.

I propose to install `xz` as part of installing all other dependencies (via system package managers) that cover all cases.