### PR TITLE
Switches from libncurses5-dev to libncurses-dev on apt systems

### DIFF
--- a/share/ruby-install/ruby/dependencies.txt
+++ b/share/ruby-install/ruby/dependencies.txt
@@ -1,4 +1,4 @@
-apt: xz-utils build-essential bison zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev
+apt: xz-utils build-essential bison zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses-dev libffi-dev
 dnf: xz gcc automake bison zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel libffi-devel
 yum: xz gcc automake bison zlib-devel libyaml-devel openssl-devel gdbm-devel readline-devel ncurses-devel libffi-devel
 port: xz automake bison readline libyaml gdbm libffi


### PR DESCRIPTION
Fixes #484