### PR TITLE
Fix RPM build on COPR

### DIFF
--- a/rpm/ruby-install.spec
+++ b/rpm/ruby-install.spec
@@ -14,6 +14,7 @@ License: MIT
 URL: https://github.com/postmodern/ruby-install#readme
 AutoReqProv: no
 BuildArch: noarch
+BuildRequires: make
 Requires: bash, grep, wget > 1.12, tar, bzip2, xz, patch
 
 %description

--- a/rpm/sources
+++ b/rpm/sources
@@ -1,1 +1,0 @@
-c24c12b179ce197e38b72ec2c80ef93e  ruby-install-0.9.4.tar.gz


### PR DESCRIPTION
It looks like all builds in existing Fedora COPR repositories are either failing or out-of-date. I created a new one at https://copr.fedorainfracloud.org/coprs/gschlager/ruby/ which I intend to keep up-to-date.

But I had to make changes to `rpm/ruby-install.spec` and delete `rpm/sources` to make the build work.