### PR TITLE
Allow to install legacy Rubies with old OpenSSL versions on Mac/Homebrew

### DIFF
--- a/share/ruby-install/ruby/dependencies.sh
+++ b/share/ruby-install/ruby/dependencies.sh
@@ -98,6 +98,7 @@ fi
 case "$package_manager" in
 	brew|port)
 		case "$ruby_version" in
+			1.8|2.[0-3])	openssl_version="1.0" ;;
 			2.*|3.0.*)	openssl_version="1.1" ;;
 			*)		openssl_version="3" ;;
 		esac
@@ -109,7 +110,11 @@ esac
 # only for homebrew.
 #
 case "$package_manager" in
-	brew)	ruby_dependencies+=("openssl@${openssl_version}") ;;
+	brew)
+		openssl_package="openssl@${openssl_version}"
+		[[ "${openssl_version}" == 1.* ]] && openssl_package="rbenv/tap/${openssl_package}"
+		ruby_dependencies+=("${openssl_package}")
+		;;
 	port)	ruby_dependencies+=("openssl${openssl_version/./}") ;;
 esac
 


### PR DESCRIPTION
This fixes two issues which prevented the use of older Rubies:

* When requiring the use of OpenSSL < 3 with MacOS / Homebrew, we use the [rbenv/homebrew-tap](https://github.com/rbenv/homebrew-tap). This is required because Homebrew [has disabled](https://formulae.brew.sh/formula/openssl@1.1) the `openssl@1.1` formula, preventing its use by default.
* Ruby before 2.4 required OpenSSL 1.0. We confiogure the rbenv tap for openssl@1.0 for these versions.

With these patches, I was able to install Ruby at least down to 2.3.7 on an M4 Mac.