### PR TITLE
Fail when there are no checksums

### DIFF
--- a/share/ruby-install/functions.sh
+++ b/share/ruby-install/functions.sh
@@ -46,6 +46,11 @@ function verify_ruby()
 
 	local file="$src_dir/$ruby_archive"
 
+	if [[ -z "${ruby_md5}${ruby_sha1}${ruby_sha256}${ruby_sha512}" ]]; then
+		error "No checksums for $ruby_archive"
+		return 1
+	fi
+
 	verify_checksum "$file" md5 "$ruby_md5"       || return $?
 	verify_checksum "$file" sha1 "$ruby_sha1"     || return $?
 	verify_checksum "$file" sha256 "$ruby_sha256" || return $?


### PR DESCRIPTION
`ruby-install` verifies checksums by default. However, it only fails if there is some checksums that mismatch.
The `--no-verify` option allows skipping of checking checksums altogether.

This change ensures that _some_ checksums were verified and not silently proceed if there are none.
The `--no-verify` option can still be used if one wishes to skip checksums verification.

```console
# clear checksums (simulate no checksums)
$ echo > ~/.cache/ruby-install/ruby/checksums.md5
$ echo > ~/.cache/ruby-install/ruby/checksums.sha1
$ echo > ~/.cache/ruby-install/ruby/checksums.sha256
$ echo > ~/.cache/ruby-install/ruby/checksums.sha512

# fail by default
$ ruby-install ruby-3.4.5
>>> Installing ruby 3.4.5 into /opt/rubies/ruby-3.4.5 ...
>>> Installing dependencies for ruby 3.4.5 ...
>>> Downloading https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.5.tar.xz into /usr/local/src ...
>>> Verifying ruby-3.4.5.tar.xz ...
!!! No checksums for ruby-3.4.5.tar.xz
!!! Verification of ruby-3.4.5.tar.xz failed!

# force install by skipping verification
$ ruby-install --no-verify ruby-3.4.5
>>> Installing ruby 3.4.5 into /opt/rubies/ruby-3.4.5 ...
>>> Installing dependencies for ruby 3.4.5 ...
>>> Downloading https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.5.tar.xz into /usr/local/src ...
>>> Extracting ruby-3.4.5.tar.xz to /usr/local/src/ruby-3.4.5 ...
>>> Configuring ruby 3.4.5 ...
```