### PR TITLE
Fix archive extraction to ensure it always extracts to the given path

### DIFF
--- a/share/ruby-install/functions.sh
+++ b/share/ruby-install/functions.sh
@@ -48,7 +48,7 @@ function verify_ruby()
 function extract_ruby()
 {
 	log "Extracting $ruby_archive to $ruby_build_dir ..."
-	extract "$src_dir/$ruby_archive" "$src_dir" || return $?
+	extract "$src_dir/$ruby_archive" "$ruby_build_dir" || return $?
 }
 
 #

--- a/share/ruby-install/jruby/functions.sh
+++ b/share/ruby-install/jruby/functions.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 ruby_archive="${ruby_archive:-jruby-dist-$ruby_version-bin.tar.gz}"
-ruby_dir_name="jruby-$ruby_version"
 ruby_mirror="${ruby_mirror:-https://repo1.maven.org/maven2/org/jruby/jruby-dist}"
 ruby_url="${ruby_url:-$ruby_mirror/$ruby_version/$ruby_archive}"
 

--- a/share/ruby-install/mruby/functions.sh
+++ b/share/ruby-install/mruby/functions.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 ruby_archive="${ruby_archive:-mruby-$ruby_version.tar.gz}"
-ruby_dir_name="mruby-$ruby_version"
 ruby_mirror="${ruby_mirror:-https://github.com/mruby/mruby/archive}"
 ruby_url="${ruby_url:-$ruby_mirror/$ruby_version/$ruby_archive}"
 

--- a/share/ruby-install/ruby-install.sh
+++ b/share/ruby-install/ruby-install.sh
@@ -295,7 +295,7 @@ function init()
 
 	ruby_cache_dir="$ruby_install_cache_dir/$ruby"
 	install_dir="${install_dir:-$rubies_dir/$ruby-$ruby_version}"
-	ruby_build_dir="$src_dir/$ruby_dir_name"
+	ruby_build_dir="$src_dir/$ruby-$ruby_version"
 
 	ruby_md5="${ruby_md5:-$(ruby_checksum_for "$ruby" md5 "$ruby_archive")}"
 	ruby_sha1="${ruby_sha1:-$(ruby_checksum_for "$ruby" sha1 "$ruby_archive")}"

--- a/share/ruby-install/ruby/functions.sh
+++ b/share/ruby-install/ruby/functions.sh
@@ -9,7 +9,6 @@ else
 fi
 
 ruby_archive="${ruby_archive:-ruby-$ruby_version.$ruby_archive_ext}"
-ruby_dir_name="ruby-$ruby_version"
 ruby_mirror="${ruby_mirror:-https://cache.ruby-lang.org/pub/ruby}"
 ruby_url="${ruby_url:-$ruby_mirror/$ruby_version_family/$ruby_archive}"
 

--- a/share/ruby-install/truffleruby-graalvm/functions.sh
+++ b/share/ruby-install/truffleruby-graalvm/functions.sh
@@ -21,17 +21,14 @@ if [[ "$ruby_version" == "23.0.0" ]]; then
 	log "TruffleRuby-GraalVM 23.0 and later installed by ruby-install use the faster Oracle GraalVM distribution"
 	log "Oracle GraalVM uses the GFTC license, which is free for development and production use, see https://medium.com/graalvm/161527df3d76"
 
-	ruby_dir_name="graalvm-jdk-17.0.7+8.1"
 	ruby_archive="${ruby_archive:-graalvm-jdk-17.0.7_${graalvm_platform/darwin/macos}-${graalvm_arch/amd64/x64}_bin.tar.gz}"
 	ruby_mirror="${ruby_mirror:-https://download.oracle.com/graalvm/17/archive}"
 	ruby_url="${ruby_url:-$ruby_mirror/$ruby_archive}"
 elif (( truffleruby_major > 23 || (truffleruby_major == 23 && truffleruby_minor >= 1) )); then # 23.1+
-	ruby_dir_name="truffleruby-$ruby_version-${graalvm_platform/darwin/macos}-$graalvm_arch"
 	ruby_archive="${ruby_archive:-truffleruby-jvm-$ruby_version-${graalvm_platform/darwin/macos}-$graalvm_arch.tar.gz}"
 	ruby_mirror="${ruby_mirror:-https://github.com/truffleruby/truffleruby/releases/download}"
 	ruby_url="${ruby_url:-$ruby_mirror/graal-$ruby_version/$ruby_archive}"
 else
-	ruby_dir_name="graalvm-ce-java11-$ruby_version"
 	ruby_archive="${ruby_archive:-graalvm-ce-java11-$graalvm_platform-$graalvm_arch-$ruby_version.tar.gz}"
 	ruby_mirror="${ruby_mirror:-https://github.com/graalvm/graalvm-ce-builds/releases/download}"
 	ruby_url="${ruby_url:-$ruby_mirror/vm-$ruby_version/$ruby_archive}"

--- a/share/ruby-install/truffleruby/functions.sh
+++ b/share/ruby-install/truffleruby/functions.sh
@@ -13,8 +13,7 @@ case "$os_arch" in
 	*)       fail "Unsupported platform $os_arch" ;;
 esac
 
-ruby_dir_name="truffleruby-$ruby_version-$truffleruby_platform-$truffleruby_arch"
-ruby_archive="${ruby_archive:-$ruby_dir_name.tar.gz}"
+ruby_archive="${ruby_archive:-truffleruby-$ruby_version-$truffleruby_platform-$truffleruby_arch.tar.gz}"
 truffleruby_major="${ruby_version%%.*}"
 
 if [[ "$ruby_version" == "23.0.0" ]]; then

--- a/share/ruby-install/util.sh
+++ b/share/ruby-install/util.sh
@@ -74,29 +74,39 @@ function download()
 function extract()
 {
 	local archive="$1"
-	local dest="${2:-${archive%/*}}"
+	local dest="$2"
+	local tmp="$dest.tmp"
 
-	mkdir -p "$dest" || return $?
+	rm -rf "$dest" "$tmp" || return $?
+	mkdir -p "$tmp" || return $?
 
 	case "$archive" in
 		*.tgz|*.tar.gz)
-			run tar -xzf "$archive" -C "$dest" || return $?
+			run tar -xzf "$archive" -C "$tmp" || return $?
 			;;
 		*.tbz|*.tbz2|*.tar.bz2)
-			run tar -xjf "$archive" -C "$dest" || return $?
+			run tar -xjf "$archive" -C "$tmp" || return $?
 			;;
 		*.txz|*.tar.xz)
-			debug "xzcat $archive | tar -xf - -C $dest"
-			xzcat "$archive" | tar -xf - -C "$dest" || return $?
+			debug "xzcat $archive | tar -xf - -C $tmp"
+			xzcat "$archive" | tar -xf - -C "$tmp" || return $?
 			;;
 		*.zip)
-			run unzip "$archive" -d "$dest" || return $?
+			run unzip "$archive" -d "$tmp" || return $?
 			;;
 		*)
 			error "Unknown archive format: $archive"
 			return 1
 			;;
 	esac
+
+	local extracted=("$tmp"/*)
+	if (( ${#extracted[@]} != 1 )); then
+		error "Multiple extracted directories under $tmp"
+		return 1
+	fi
+	mv "${extracted[0]}" "$dest" || return $?
+	rm -rf "$tmp"
 }
 
 #

--- a/test/functions-tests/apply_patches_test.sh
+++ b/test/functions-tests/apply_patches_test.sh
@@ -4,17 +4,17 @@
 . ./share/ruby-install/functions.sh
 
 src_dir="$test_fixtures_dir/apply_patches_test"
-ruby_dir_name="ruby-1.9.3-p448"
-ruby_build_dir="$src_dir/$ruby_dir_name"
+ruby_and_version="ruby-1.9.3-p448"
+ruby_build_dir="$src_dir/$ruby_and_version"
 
 patches=("$ruby_build_dir/falcon-gc.diff")
 
 function setUp()
 {
 	mkdir -p "$ruby_build_dir"
-	echo "diff -Naur $ruby_dir_name.orig/test $ruby_dir_name/test
---- $ruby_dir_name.orig/test 1970-01-01 01:00:00.000000000 +0100
-+++ $ruby_dir_name/test  2013-08-02 20:57:08.055843749 +0200
+	echo "diff -Naur $ruby_and_version.orig/test $ruby_and_version/test
+--- $ruby_and_version.orig/test 1970-01-01 01:00:00.000000000 +0100
++++ $ruby_and_version/test  2013-08-02 20:57:08.055843749 +0200
 @@ -0,0 +1 @@
 +patch
 " > "${patches[0]}"

--- a/test/functions-tests/download_patches_test.sh
+++ b/test/functions-tests/download_patches_test.sh
@@ -4,8 +4,8 @@
 . ./share/ruby-install/functions.sh
 
 src_dir="$test_fixtures_dir/download_patches_test"
-ruby_dir_name="ruby-1.9.3-p448"
-ruby_build_dir="$src_dir/$ruby_dir_name"
+ruby_and_version="ruby-1.9.3-p448"
+ruby_build_dir="$src_dir/$ruby_and_version"
 
 patches=("https://gist.github.com/funny-falcon/2981959/raw/ary-queue.diff" "local.patch")
 
@@ -18,7 +18,7 @@ function test_download_patches()
 {
 	download_patches 2>/dev/null
 
-	assertTrue "did not download patches to \$src_dir/\$ruby_dir_name" \
+	assertTrue "did not download patches to \$src_dir/\$ruby_and_version" \
 		   '[[ -f "${ruby_build_dir}/ary-queue.diff" ]]'
 
 	assertEquals "did not update \$patches" \

--- a/test/jruby-tests/functions_test.sh
+++ b/test/jruby-tests/functions_test.sh
@@ -31,13 +31,6 @@ function test_ruby_archive_when_its_already_set()
 	             "$ruby_archive"
 }
 
-function test_ruby_dir_name()
-{
-	assertEquals "did not correctly set \$ruby_dir_name" \
-	             "jruby-$ruby_version" \
-	             "$ruby_dir_name"
-}
-
 function test_ruby_mirror_default_value()
 {
 	assertEquals "did not correctly set \$ruby_mirror" \
@@ -78,7 +71,7 @@ function test_ruby_url_when_its_already_set()
 
 function tearDown()
 {
-	unset ruby ruby_version ruby_archive ruby_dir_name ruby_mirror ruby_url
+	unset ruby ruby_version ruby_archive ruby_mirror ruby_url
 }
 
 SHUNIT_PARENT=$0 . $SHUNIT2

--- a/test/mruby-tests/functions_test.sh
+++ b/test/mruby-tests/functions_test.sh
@@ -31,13 +31,6 @@ function test_ruby_archive_when_its_already_set()
 	             "$ruby_archive"
 }
 
-function test_ruby_dir_name()
-{
-	assertEquals "did not correctly set \$ruby_dir_name" \
-	             "mruby-$ruby_version" \
-	             "$ruby_dir_name"
-}
-
 function test_ruby_mirror_default_value()
 {
 	assertEquals "did not correctly set \$ruby_mirror" \
@@ -78,7 +71,7 @@ function test_ruby_url_when_its_already_set()
 
 function tearDown()
 {
-	unset ruby ruby_version ruby_archive ruby_dir_name ruby_mirror ruby_url
+	unset ruby ruby_version ruby_archive ruby_mirror ruby_url
 }
 
 SHUNIT_PARENT=$0 . $SHUNIT2

--- a/test/ruby-tests/functions_test.sh
+++ b/test/ruby-tests/functions_test.sh
@@ -57,13 +57,6 @@ function test_ruby_archive_when_its_already_set()
 	             "$ruby_archive"
 }
 
-function test_ruby_dir_name()
-{
-	assertEquals "did not correctly set \$ruby_dir_name" \
-	             "ruby-$ruby_version" \
-	             "$ruby_dir_name"
-}
-
 function test_ruby_mirror_default_value()
 {
 	assertEquals "did not correctly set \$ruby_mirror" \
@@ -104,7 +97,7 @@ function test_ruby_url_when_its_already_set()
 
 function tearDown()
 {
-	unset ruby ruby_version ruby_version_family ruby_archive ruby_dir_name \
+	unset ruby ruby_version ruby_version_family ruby_archive \
 	      ruby_mirror ruby_url
 }
 

--- a/test/truffleruby-graalvm-tests/functions_test.sh
+++ b/test/truffleruby-graalvm-tests/functions_test.sh
@@ -113,42 +113,6 @@ function test_truffleruby_minor()
 	             "$truffleruby_minor"
 }
 
-function test_ruby_dir_name_when_ruby_version_is_23_0_0()
-{
-	ruby_version="23.0.0"
-
-	source "$ruby_install_dir/functions.sh"
-	source "$ruby_install_dir/truffleruby-graalvm/functions.sh" >/dev/null
-
-	assertEquals "did not correctly set \$ruby_dir_name" \
-	             "graalvm-jdk-17.0.7+8.1" \
-	             "$ruby_dir_name"
-}
-
-function test_ruby_dir_name_when_ruby_version_is_greater_or_equal_to_23_1_0()
-{
-	ruby_version="23.1.0"
-
-	source "$ruby_install_dir/functions.sh"
-	source "$ruby_install_dir/truffleruby-graalvm/functions.sh"
-
-	assertEquals "did not correctly set \$ruby_dir_name" \
-	             "truffleruby-$ruby_version-${graalvm_platform/darwin/macos}-$graalvm_arch" \
-	             "$ruby_dir_name"
-}
-
-function test_ruby_dir_name_when_ruby_version_is_less_than_23_0_0()
-{
-	ruby_version="22.1.0"
-
-	source "$ruby_install_dir/functions.sh"
-	source "$ruby_install_dir/truffleruby-graalvm/functions.sh"
-
-	assertEquals "did not correctly set \$ruby_dir_name" \
-	             "graalvm-ce-java11-$ruby_version" \
-	             "$ruby_dir_name"
-}
-
 function test_ruby_archive_default_value_when_ruby_version_is_23_0_0()
 {
 	ruby_version="23.0.0"
@@ -372,7 +336,7 @@ function test_ruby_url_when_its_already_set_and_when_ruby_version_is_less_than_2
 
 function tearDown()
 {
-	unset ruby ruby_version ruby_version_family ruby_archive ruby_dir_name \
+	unset ruby ruby_version ruby_version_family ruby_archive \
 	      ruby_mirror ruby_url
 }
 

--- a/test/truffleruby-tests/functions_test.sh
+++ b/test/truffleruby-tests/functions_test.sh
@@ -131,13 +131,6 @@ function test_ruby_archive_when_its_already_set_and_when_ruby_version_is_less_th
 	             "$ruby_archive"
 }
 
-function test_ruby_dir_name()
-{
-	assertEquals "did not correctly set \$ruby_dir_name" \
-	             "truffleruby-$ruby_version-$truffleruby_platform-$truffleruby_arch" \
-	             "$ruby_dir_name"
-}
-
 function test_ruby_mirror_default_value_when_ruby_version_is_greater_or_equal_to_23_0_0()
 {
 	ruby_version="23.0.0"
@@ -244,7 +237,7 @@ function test_ruby_url_when_its_already_set_and_ruby_version_is_less_than_23_0_0
 
 function tearDown()
 {
-	unset ruby ruby_version ruby_version_family ruby_archive ruby_dir_name \
+	unset ruby ruby_version ruby_version_family ruby_archive \
 	      ruby_mirror ruby_url
 }
 


### PR DESCRIPTION
* Fixes https://github.com/postmodern/ruby-install/issues/522
* The various functions.sh no longer need to hardcode $ruby_dir_name.
* Remove $ruby_dir_name entirely as it is now unused.